### PR TITLE
ci: pin toolchain to 1.96.0 and skip GPU tests on CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: rustfmt
       - run: cargo fmt --check
@@ -34,7 +34,7 @@ jobs:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
       - name: Build (rustc-warning-clean gate)
         run: cargo build --release
         env:
@@ -57,7 +57,7 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@1.96.0
         with:
           components: clippy
       - run: cargo clippy --release
@@ -71,7 +71,7 @@ jobs:
 #     runs-on: [self-hosted, macos, dgq-weights]
 #     steps:
 #       - uses: actions/checkout@v4
-#       - uses: dtolnay/rust-toolchain@stable
+#       - uses: dtolnay/rust-toolchain@1.96.0
 #       - run: cargo build --release
 #       - name: Golden byte-identity pack (Tier-1 refactor gate — task #73;
 #         # exact token_ids + causal-KV hash across the prefill/generation path

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,7 @@
+# Pin the toolchain so rustfmt output and clippy lints stay deterministic.
+# CI installs this exact version too (see .github/workflows/ci.yml). An unpinned
+# `@stable` let rustfmt drift once and silently reflow the whole tree, so the
+# fmt version is now nailed down here and there in lockstep. Bump both together.
+[toolchain]
+channel = "1.96.0"
+components = ["rustfmt", "clippy"]

--- a/src/metal/batched_kernels.rs
+++ b/src/metal/batched_kernels.rs
@@ -317,6 +317,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_gelu_large_input() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let mut cpu = vec![10.229641f32];
         let mut gpu = cpu.clone();
         gelu_pytorch_tanh(&mut cpu);
@@ -336,6 +339,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_gelu_matches_cpu() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let mut cpu = vec![-2.0f32, -1.0, 0.0, 0.5, 1.5, 3.0];
         let mut gpu = cpu.clone();
         gelu_pytorch_tanh(&mut cpu);
@@ -358,6 +364,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_gelu_matches_cpu_mlp_shape() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let len = 16 * 2112;
         let data: Vec<f32> = (0..len).map(|i| ((i as f32) * 0.001).sin()).collect();
         let mut cpu = data.clone();

--- a/src/metal/gemm.rs
+++ b/src/metal/gemm.rs
@@ -338,6 +338,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_f32_bf16_linear_matches_cpu_decoder_mlp_shape() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let m = 256usize;
         let k = 2816usize;
         let n = 2112usize;
@@ -364,6 +367,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_gemm_matches_cpu_decoder_mlp_shape() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let m = 256usize;
         let k = 2816usize;
         let n = 2112usize;

--- a/src/metal/sampler.rs
+++ b/src/metal/sampler.rs
@@ -245,6 +245,9 @@ mod tests {
 
     #[test]
     fn gpu_postprocess_matches_cpu() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let canvas_len = 8usize;
         let vocab = 512usize;
         let total = canvas_len * vocab;

--- a/src/shaders/attn/apply_rope_heads/mod.rs
+++ b/src/shaders/attn/apply_rope_heads/mod.rs
@@ -244,21 +244,33 @@ mod tests {
 
     #[test]
     fn cpu_tiny() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(tiny_fixture, 1e-5);
     }
 
     #[test]
     fn cpu_sliding_prefill() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(sliding_prefill_fixture, 1e-5);
     }
 
     #[test]
     fn cpu_full_partial() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(full_partial_fixture, 1e-5);
     }
 
     #[test]
     fn cpu_k_offset() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(k_offset_fixture, 1e-5);
     }
 

--- a/src/shaders/attn/attention_flash/mod_tests.rs
+++ b/src/shaders/attn/attention_flash/mod_tests.rs
@@ -61,6 +61,9 @@ fn flash_blocked_matches_cpu_causal_sliding_hd256_f16() {
 #[cfg(target_os = "macos")]
 #[test]
 fn flash_gpu_full_grp8_causal_vs_cpu() {
+    if crate::shaders::test_util::skip_gpu_on_ci() {
+        return;
+    }
     use crate::shaders::attn::attention_flash::gpu_flash;
     use crate::shaders::test_util::assert_oracle;
     let f = full_grp8_hd512_fixture(ElemFormat::F32);
@@ -72,6 +75,9 @@ fn flash_gpu_full_grp8_causal_vs_cpu() {
 #[cfg(target_os = "macos")]
 #[test]
 fn flash_gpu_full_grp2_causal_vs_cpu() {
+    if crate::shaders::test_util::skip_gpu_on_ci() {
+        return;
+    }
     use crate::shaders::attn::attention_flash::gpu_flash;
     use crate::shaders::test_util::assert_oracle;
     let f = full_hd512_fixture(ElemFormat::F32);

--- a/src/shaders/attn/attention_gemm/mod.rs
+++ b/src/shaders/attn/attention_gemm/mod.rs
@@ -712,6 +712,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn attn_gemm_full_grp8_vs_cpu() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         use crate::shaders::test_util::{ElemFormat, assert_oracle};
         let f = crate::shaders::attention::full_grp8_hd512_fixture(ElemFormat::F32);
         let got = gpu(&f, false, false).expect("gpu attn_gemm");
@@ -722,6 +725,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn attn_gemm_full_grp2_vs_cpu() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         use crate::shaders::test_util::{ElemFormat, assert_oracle};
         let f = crate::shaders::attention::full_hd512_fixture(ElemFormat::F32);
         let got = gpu(&f, false, false).expect("gpu attn_gemm");
@@ -735,6 +741,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn attn_gemm_full_grp8_causal_vs_cpu() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         use crate::shaders::test_util::{ElemFormat, assert_oracle};
         let f = crate::shaders::attention::full_grp8_hd512_fixture(ElemFormat::F32);
         let got = gpu(&f, true, false).expect("gpu attn_gemm causal");
@@ -747,6 +756,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn attn_gemm_full_grp8_causal_side_vs_cpu() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         use crate::shaders::test_util::{ElemFormat, assert_oracle};
         let f = crate::shaders::attention::full_grp8_hd512_fixture(ElemFormat::F32);
         let got = gpu(&f, true, true).expect("gpu attn_gemm causal side");

--- a/src/shaders/attn/attention_topk/mod.rs
+++ b/src/shaders/attn/attention_topk/mod.rs
@@ -451,6 +451,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn topk_full_grp8_causal_vs_cpu() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let f = crate::shaders::attention::full_grp8_hd512_fixture(ElemFormat::F32);
         let got = gpu(&f, true, false, K_PAD).expect("gpu topk causal");
         let oracle = cpu::topk_causal(&f, true, K_PAD);
@@ -467,6 +470,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn topk_full_grp8_denoise_vs_cpu() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let f = crate::shaders::attention::full_grp8_hd512_fixture(ElemFormat::F32);
         let got = gpu(&f, false, false, K_PAD).expect("gpu topk denoise");
         let oracle = cpu::topk_denoise(&f, true, K_PAD);
@@ -477,6 +483,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn topk_full_grp8_causal_side_vs_cpu() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let f = crate::shaders::attention::full_grp8_hd512_fixture(ElemFormat::F32);
         let got = gpu(&f, true, true, K_PAD).expect("gpu topk causal side");
         let oracle = cpu::topk_causal(&f, false, K_PAD);
@@ -491,6 +500,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn topk_k1_matches_argmax_value() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let f = crate::shaders::attention::full_grp8_hd512_fixture(ElemFormat::F32);
         let got = gpu(&f, true, false, 1).expect("gpu topk k=1");
         let oracle = cpu::topk_causal(&f, true, 1);
@@ -504,6 +516,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn topk_k128_matches_cpu() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let f = crate::shaders::attention::full_grp8_hd512_fixture(ElemFormat::F32);
         let got = gpu(&f, true, false, 128).expect("gpu topk k=128");
         let oracle = cpu::topk_causal(&f, true, 128);

--- a/src/shaders/attn/gqa_attention/mod.rs
+++ b/src/shaders/attn/gqa_attention/mod.rs
@@ -463,36 +463,57 @@ mod tests {
 
     #[test]
     fn cpu_tiny() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(tiny_fixture, 1e-4);
     }
 
     #[test]
     fn cpu_sliding_prefill() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(sliding_prefill_fixture, 1e-4);
     }
 
     #[test]
     fn cpu_encoder_extend() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(encoder_extend_fixture, 1e-4);
     }
 
     #[test]
     fn cpu_full_layer() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(full_layer_fixture, 1e-4);
     }
 
     #[test]
     fn cpu_decoder_bitmap() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(decoder_bitmap_fixture, 1e-4);
     }
 
     #[test]
     fn cpu_sparse_decoder_bitmap() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(sparse_decoder_bitmap_fixture, 1e-4);
     }
 
     #[test]
     fn cpu_sliding_tight() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(sliding_tight_fixture, 1e-4);
     }
 }

--- a/src/shaders/common/test_util.rs
+++ b/src/shaders/common/test_util.rs
@@ -57,6 +57,15 @@ pub fn assert_oracle(a: &[f32], b: &[f32], max_tol: f32, min_cos: f32) {
     );
 }
 
+/// Hosted CI runners (`CI=true`, e.g. GitHub Actions) have no usable Metal
+/// device, so kernel tests that dispatch to the GPU early-return there. CPU
+/// oracle tests still run. A local run (no `CI` in the environment) exercises
+/// the GPU as normal. This is the single gate every GPU test consults.
+#[cfg(test)]
+pub fn skip_gpu_on_ci() -> bool {
+    std::env::var_os("CI").is_some()
+}
+
 /// Expand fixture × format cells into CPU-only and GPU-vs-CPU oracle tests.
 #[macro_export]
 macro_rules! kernel_oracle_matrix {
@@ -94,6 +103,9 @@ macro_rules! kernel_oracle_matrix {
                     #[cfg(target_os = "macos")]
                     #[test]
                     fn gpu_matches_cpu() {
+                        if $crate::shaders::test_util::skip_gpu_on_ci() {
+                            return;
+                        }
                         let fix = $fixture_fn(ElemFormat::$fmt);
                         let cpu = $cpu_fn(&fix);
                         let gpu = $gpu_fn(&fix, $crate::shaders::KernelVariant::PRODUCTION)
@@ -104,6 +116,9 @@ macro_rules! kernel_oracle_matrix {
                     #[cfg(target_os = "macos")]
                     #[test]
                     fn gpu_assert_variant_matches_cpu() {
+                        if $crate::shaders::test_util::skip_gpu_on_ci() {
+                            return;
+                        }
                         let fix = $fixture_fn(ElemFormat::$fmt);
                         let cpu = $cpu_fn(&fix);
                         let gpu = $gpu_fn(&fix, $crate::shaders::KernelVariant::TEST_ASSERT)

--- a/src/shaders/elementwise/convert_scale/mod.rs
+++ b/src/shaders/elementwise/convert_scale/mod.rs
@@ -85,6 +85,9 @@ mod tests {
     /// mirror at the arena's bf16 precision (bf16-exact inputs).
     #[test]
     fn all_four_corners_match_cpu() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         // bf16-exact input values so arena round-trips are exact.
         let src_f32_vals: Vec<f32> = (0..16).map(|i| (i as f32 - 8.0) * 0.5).collect();
         let scale = 0.25f32;

--- a/src/shaders/elementwise/gather_rows/mod.rs
+++ b/src/shaders/elementwise/gather_rows/mod.rs
@@ -309,6 +309,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn format_specializations_agree() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let f = tiny_fixture(ElemFormat::F32);
         let expect = cpu(&f);
         for (sf, df, label) in [

--- a/src/shaders/elementwise/scatter_rows_weighted/mod.rs
+++ b/src/shaders/elementwise/scatter_rows_weighted/mod.rs
@@ -76,6 +76,9 @@ mod tests {
 
     #[test]
     fn gpu_matches_cpu_reference() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let seq_len = 5usize;
         let hidden = 32usize;
         let top_k = 3usize;

--- a/src/shaders/gemm/gemm_int_sparse/mod.rs
+++ b/src/shaders/gemm/gemm_int_sparse/mod.rs
@@ -313,6 +313,9 @@ mod tests {
     /// path (same shape contract as gemm_tunable::sparse_block_m_invariant).
     #[test]
     fn sparse_int8_matches_cpu_oracle() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let counts: &[usize] = &[200, 77, 150, 5, 300, 33, 128];
         let f = grouped_int_fixture(256, 128, counts);
         let (a_int8, w_int8, scale_a, scale_w) = f.int8_side_channel();
@@ -344,6 +347,9 @@ mod tests {
     /// process to force the collision if the source-hash fix regresses.
     #[test]
     fn sparse_int8_block_m_invariant() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let counts: &[usize] = &[200, 77, 150, 5, 300, 33, 128];
         let f = grouped_int_fixture(256, 128, counts);
         let (a_int8, w_int8, scale_a, scale_w) = f.int8_side_channel();

--- a/src/shaders/gemm/gemm_linear_grouped/mod.rs
+++ b/src/shaders/gemm/gemm_linear_grouped/mod.rs
@@ -487,6 +487,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_tiled_grouped_matches_linear_grouped_nvfp4() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         use crate::shaders::gemm_block_grouped;
         use crate::shaders::test_util::{ElemFormat, assert_oracle};
         use crate::shaders::variant::KernelVariant;

--- a/src/shaders/gemm/gemm_tunable/mod.rs
+++ b/src/shaders/gemm/gemm_tunable/mod.rs
@@ -552,6 +552,9 @@ mod stacked_nvfp4_tests {
     /// range decode). Covers the qkv (3-seg) and gate/up (2-seg) layouts.
     #[test]
     fn stacked_nvfp4_bitexact_vs_gemm_block_stacked() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         for fixture_fn in [
             gemm_block_stacked::gate_up_tiny_fixture as fn(_) -> _,
             gemm_block_stacked::qkv_tiny_fixture,
@@ -640,6 +643,9 @@ mod dense_nvfp4_tests {
     /// to the dense W-load when gemm_block was retired.
     #[test]
     fn dense_nvfp4_bitexact_vs_gemm_block() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         for fixture_fn in [
             gemm_nvfp4::tile_fixture as fn(_) -> _,
             gemm_nvfp4::gscale_fixture,
@@ -662,6 +668,9 @@ mod dense_nvfp4_tests {
     /// tracks the CPU reference within quant tolerance.
     #[test]
     fn dense_nvfp4_matches_cpu_oracle() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let f = gemm_nvfp4::tile_fixture(ElemFormat::F32);
         let tuned = gpu_dense_tunable_nvfp4(&f).expect("tunable dense");
         let oracle = gemm_nvfp4::cpu(&f);
@@ -683,6 +692,9 @@ mod sparse_nvfp4_tests {
     /// cross-check retired with that kernel.)
     #[test]
     fn sparse_nvfp4_matches_cpu_oracle() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let f = grouped_fixture(QuantFormat::NvFp4, 64, 192, COUNTS);
         let tuned = gpu_sparse_tunable(&f).expect("tunable sparse");
         let oracle = crate::shaders::gemm_block_grouped::cpu(&f);
@@ -703,6 +715,9 @@ mod sparse_nvfp4_tests {
     /// PROCESS specifically to force that collision if it ever regresses.
     #[test]
     fn sparse_block_m_invariant() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let counts: &[usize] = &[200, 77, 150, 5, 300, 33, 128];
         let f = grouped_fixture(QuantFormat::Q4Affine, 128, 256, counts);
         let oracle = crate::shaders::gemm_block_grouped::cpu(&f);
@@ -790,6 +805,9 @@ mod w32_tests {
     /// W-load and both nvfp4 fixtures (incl. the non-trivial global scale).
     #[test]
     fn w32_bitexact_vs_byte_loads() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let ctx = MetalContext::new().expect("metal ctx");
         let src0 = tuned_source_w32(TUNE_BM, TUNE_BN, false);
         let src1 = tuned_source_w32(TUNE_BM, TUNE_BN, true);
@@ -846,6 +864,9 @@ mod double_buffer_tests {
     /// are unchanged — only the tgmem buffering schedule differs).
     #[test]
     fn gemm_tunable_db_bitexact_vs_single_buffer() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let ctx = MetalContext::new().expect("metal ctx");
         let mut pool = BufferPool::new();
         // tile_fixture: m=8, n=128, k=128 — exercises multiple K-tiles (BK=32

--- a/src/shaders/kv/pack_encoder_kv/mod.rs
+++ b/src/shaders/kv/pack_encoder_kv/mod.rs
@@ -295,6 +295,9 @@ mod roundtrip_tests {
     /// the linear slot indexing with zero rounding-mode ambiguity.
     #[test]
     fn pack_unpack_roundtrip_f16_linear() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let tc = 6;
         let n = tc * NKV * HD;
         let keys: Vec<f32> = wave(n, 0.0, 3.0, 0.017)
@@ -316,6 +319,9 @@ mod roundtrip_tests {
     /// so the identity must still hold bit-for-bit.
     #[test]
     fn pack_unpack_roundtrip_f16_ring_wrap() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let tc = 4;
         let n = tc * NKV * HD;
         let keys: Vec<f32> = wave(n, 0.5, 3.0, 0.017)
@@ -337,6 +343,9 @@ mod roundtrip_tests {
     /// token lands where → error explodes far past this bound).
     #[test]
     fn pack_unpack_roundtrip_q8_linear() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let tc = 6;
         let n = tc * NKV * HD;
         let keys = wave(n, 0.0, 3.0, 0.017);
@@ -375,6 +384,9 @@ mod roundtrip_tests {
     /// this armor is independent of any CPU f16/q8 rounding model.
     #[test]
     fn hydrate_matches_unpack_f16() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let tc = 6;
         let n = tc * NKV * HD;
         let keys: Vec<f32> = wave(n, 0.0, 3.0, 0.017)
@@ -393,6 +405,9 @@ mod roundtrip_tests {
 
     #[test]
     fn hydrate_matches_unpack_q8() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let tc = 6;
         let n = tc * NKV * HD;
         let keys = wave(n, 0.0, 3.0, 0.017);

--- a/src/shaders/moe/router_top_k_rows/mod.rs
+++ b/src/shaders/moe/router_top_k_rows/mod.rs
@@ -227,6 +227,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_matches_cpu_tiny() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let fix = tiny_fixture(ElemFormat::F32);
         let cpu = cpu(&fix);
         let gpu = gpu(&fix, KernelVariant::PRODUCTION).expect("gpu");
@@ -236,6 +239,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_matches_cpu_moe() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let fix = moe_fixture(ElemFormat::F32);
         let cpu = cpu(&fix);
         let gpu = gpu(&fix, KernelVariant::PRODUCTION).expect("gpu");

--- a/src/shaders/oracle/gemm/gemm_block_stacked/mod.rs
+++ b/src/shaders/oracle/gemm/gemm_block_stacked/mod.rs
@@ -738,6 +738,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn stacked_gpu_matches_split_gate_up_canvas() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         use crate::shaders::variant::KernelVariant;
         let f = gate_up_canvas_fixture(ElemFormat::F32);
         let stacked = gpu_q4(&f, KernelVariant::PRODUCTION).expect("stacked");
@@ -749,6 +752,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn stacked_gpu_matches_split_gate_up_tiny() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         use crate::shaders::variant::KernelVariant;
         let f = gate_up_tiny_fixture(ElemFormat::F32);
         let stacked = gpu_q4(&f, KernelVariant::PRODUCTION).expect("stacked");
@@ -760,6 +766,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn stacked_gpu_matches_split_qkv_sliding_prod() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         use crate::shaders::variant::KernelVariant;
         let f = qkv_sliding_prod_fixture(ElemFormat::F32);
         let stacked = gpu_q4(&f, KernelVariant::PRODUCTION).expect("stacked");

--- a/src/shaders/oracle/gemm/gemm_nvfp4.rs
+++ b/src/shaders/oracle/gemm/gemm_nvfp4.rs
@@ -120,6 +120,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_tiled_matches_linear_f32() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         for fixture_fn in [tiny_fixture as fn(_) -> _, tile_fixture, gscale_fixture] {
             let gf = fixture_fn(ElemFormat::F32);
             let lf = linear_f32_fixture(&gf);

--- a/src/shaders/oracle/sampler/argmax_rows/mod.rs
+++ b/src/shaders/oracle/sampler/argmax_rows/mod.rs
@@ -131,23 +131,35 @@ mod tests {
 
     #[test]
     fn cpu_tiny() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(tiny_fixture, 0.0);
     }
 
     #[test]
     fn cpu_canvas_vocab() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(canvas_vocab_fixture, 0.0);
     }
 
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_tiny() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(tiny_fixture, 0.0);
     }
 
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_canvas_vocab() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(canvas_vocab_fixture, 0.0);
     }
 }

--- a/src/shaders/oracle/sampler/ranged.rs
+++ b/src/shaders/oracle/sampler/ranged.rs
@@ -187,11 +187,17 @@ mod tests {
 
         #[test]
         fn gpu_softcap_matches_cpu() {
+            if crate::shaders::test_util::skip_gpu_on_ci() {
+                return;
+            }
             run(RangedOp::Softcap, 0.000011);
         }
 
         #[test]
         fn gpu_scale_matches_cpu() {
+            if crate::shaders::test_util::skip_gpu_on_ci() {
+                return;
+            }
             run(RangedOp::Scale, 0.000013);
         }
     }

--- a/src/shaders/oracle/sampler/row_entropy/mod.rs
+++ b/src/shaders/oracle/sampler/row_entropy/mod.rs
@@ -121,23 +121,35 @@ mod tests {
 
     #[test]
     fn cpu_tiny() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(tiny_fixture, 1e-4);
     }
 
     #[test]
     fn cpu_canvas_vocab() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(canvas_vocab_fixture, 2.5e-2);
     }
 
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_tiny() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(tiny_fixture, 1e-4);
     }
 
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_canvas_vocab() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(canvas_vocab_fixture, 2.5e-2);
     }
 }

--- a/src/shaders/oracle/sampler/scatter_vocab_chunk/mod.rs
+++ b/src/shaders/oracle/sampler/scatter_vocab_chunk/mod.rs
@@ -158,23 +158,35 @@ mod tests {
 
     #[test]
     fn cpu_tiny() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(tiny_fixture, 0.0);
     }
 
     #[test]
     fn cpu_lm_head_chunk() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(lm_head_chunk_fixture, 0.0);
     }
 
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_tiny() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(tiny_fixture, 0.0);
     }
 
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_lm_head_chunk() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         run_matrix(lm_head_chunk_fixture, 0.0);
     }
 }

--- a/src/shaders/oracle/sampler/softmax_rows/mod.rs
+++ b/src/shaders/oracle/sampler/softmax_rows/mod.rs
@@ -282,6 +282,9 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn gpu_row_invariants() {
+        if crate::shaders::test_util::skip_gpu_on_ci() {
+            return;
+        }
         let fix = router_fixture(ElemFormat::F32);
         let out = gpu(&fix, KernelVariant::PRODUCTION).expect("gpu");
         assert_row_invariants(&out, fix.rows, fix.cols);


### PR DESCRIPTION
Gets CI green by removing two failures that had nothing to do with any code change: rustfmt version drift and GPU tests running on a GPU-less runner.

## Why

CI had been red on `main` and `v0.1.0` for two independent reasons:

- **fmt** — CI runs `cargo fmt --check` on unpinned `dtolnay/rust-toolchain@stable`. When stable moved to rustfmt 1.9.0 it reflowed files no one had touched, so the job failed on pure toolchain drift.
- **build-test** — GitHub-hosted macOS runners have no usable Metal GPU, so the ~270 kernel tests that dispatch to the device fail there. This only surfaced recently: the job used to fail earlier at the rustc-warning gate, so the test phase was never reached.

## What changed

**Pin the toolchain (`4aad39a`)**
- `rust-toolchain.toml` pins `channel = "1.96.0"` with `rustfmt` + `clippy` components.
- Every CI job installs that exact version (`@stable` → `@1.96.0`) so fmt output and clippy lints stay deterministic. Bump both together.

**Skip GPU tests on CI (`ccbab7e`)**
- One gate, `test_util::skip_gpu_on_ci()` (keyed on `CI=true`), that every GPU test consults and early-returns from. CPU oracle tests still run.
- The `kernel_oracle_matrix!` macro carries the gate for its **204** generated `gpu_matches_cpu` / `gpu_assert_variant_matches_cpu` tests from a single spot.
- The **67** hand-rolled GPU tests each take the one-line guard.

## Verification

- `CI=true cargo test` → **749 passed / 0 failed / 33 ignored**.
- A normal local run (no `CI`) still exercises every GPU test — the gate is CI-only.
- `cargo fmt --check` clean, `cargo build --all-targets` 0 warnings.
- Live CI on this branch is green end-to-end: **fmt ✓, clippy ✓, build-test ✓**.

## Reviewer notes

- The gate is intentionally keyed on the `CI` env var (set automatically by GitHub Actions), not on probing for a device, matching the request to disable GPU tests specifically when `CI=true`.
- Follow-up left out of scope: the `clippy` job is still `continue-on-error: true` even though clippy is now clean — it could become a hard gate in a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
