### PR TITLE
serve: tool-turn continuation + forced-open thought in tool mode

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -657,6 +657,18 @@ artifact.
   conversation with the longest common prefix and salvages tail divergence
   (lcp ≥ 256 && tail ≤ 512 → O(1) ring truncate on Activate); anything
   deeper is an explicit, logged decision to re-prefill.
+- **Tool-turn continuation** (`DGQ_SERVE_TOOL_CONTINUATION`, default ON):
+  a tool-mode generation prompt seeds the thought channel OPEN (reasoning
+  lands in the thought block by construction; `DiffusionStreamMapper`
+  starts in-thought so the wire split agrees), and a request recognized as
+  the previous tool turn's next round (`match_tool_continuation`: same
+  message prefix + our echoed calls + their responses) prompts as the raw
+  token log — reasoning intact — plus the rendered responses and a
+  reopened thought. Mid-turn rounds finalize the raw log (a no-op rebuild;
+  pure KV extension per round); the round that ends the turn finalizes
+  thought-free as always, so reasoning still never crosses a turn
+  boundary. Fixes the intra-turn amnesia of the thought-stripping
+  re-render (the model re-planned from scratch every round).
 - **Standing gate — rewind byte-consistency**: seeded
   generate → rewind → generate loops must restore KV bytes exactly
   (position-ordered `live_kv_fingerprint`) and regenerate bit-identically.

--- a/src/flags/accessors.rs
+++ b/src/flags/accessors.rs
@@ -328,6 +328,13 @@ pub fn prefill_status_enabled() -> bool {
     config().server.prefill_status
 }
 
+/// `DGQ_SERVE_TOOL_CONTINUATION` (default ON, `=0` disables): serve prompts a
+/// recognized tool-turn extension with the previous round's raw token log —
+/// reasoning intact — instead of the thought-free re-render.
+pub fn serve_tool_continuation_enabled() -> bool {
+    config().server.serve_tool_continuation
+}
+
 /// `DGQ_TOOL_REPAIR=1`: model-guided tool-call repair (error tool-response →
 /// corrected call → corrupt exchange rewound out of KV). Equivalent to
 /// `serve --tool-repair`. Default OFF.

--- a/src/flags/mod.rs
+++ b/src/flags/mod.rs
@@ -435,6 +435,12 @@ pub struct ServerFlags {
     /// Default OFF since the strain battery showed the premature stop is a
     /// degradation symptom and the forced continuation floods. Opt-in.
     pub continue_past_stop: bool,
+    /// `DGQ_SERVE_TOOL_CONTINUATION`: a tool-mode request that extends the
+    /// previous tool turn (same messages + our returned calls + their
+    /// responses) prompts as the resident raw token log — reasoning intact —
+    /// plus the rendered responses and a reopened thought, instead of the
+    /// thought-free re-render. Default ON; `=0` off.
+    pub serve_tool_continuation: bool,
     /// `DGQ_TOOL_COMPACT`: enable the tool-output compactor. Default OFF.
     pub tool_compact: bool,
     /// `DGQ_TOOL_REPAIR`: serve's model-guided tool-call repair — an invalid
@@ -717,6 +723,7 @@ impl RuntimeConfig {
                     .unwrap_or_else(default_conv_cache_dir),
                 continue_past_stop: r.on_if_one("DGQ_CONTINUE_PAST_STOP"),
                 prefill_status: r.on_unless_zero("DGQ_PREFILL_STATUS"),
+                serve_tool_continuation: r.on_unless_zero("DGQ_SERVE_TOOL_CONTINUATION"),
                 tool_compact: r.on_if_one("DGQ_TOOL_COMPACT"),
                 tool_repair: r.on_if_one("DGQ_TOOL_REPAIR"),
                 tool_validate: r.on_if_one("DGQ_TOOL_VALIDATE"),

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -158,6 +158,113 @@ pub(crate) enum ServerEvent {
 }
 
 // ===========================================================================
+// Tool-turn continuation (the intra-turn amnesia fix, ported from chat).
+//
+// The client drives the tool loop over HTTP: it posts the whole conversation
+// back with our returned `tool_calls` echoed and `tool`-role responses
+// appended. Re-rendering that conversation strips the model's reasoning, so
+// each round used to re-plan from scratch (observed as repeated identical
+// exploratory calls). Instead, the worker remembers the raw token log of the
+// turn it just answered with tool calls; a request recognized as that turn's
+// next round prompts as the raw log — reasoning intact — plus the rendered
+// responses and a reopened thought, and is a pure KV extension.
+// ===========================================================================
+
+/// What the worker remembers after answering a tool-mode request with tool
+/// calls: enough to recognize the turn's next round and extend it verbatim.
+pub(crate) struct PendingToolTurn {
+    /// The request's `messages` exactly as received.
+    pub messages: Vec<serde_json::Value>,
+    /// The OpenAI-format `tool_calls` we returned (ids `call_0`, `call_1`, …).
+    pub tool_calls: Vec<serde_json::Value>,
+    /// Full raw token log of the turn so far: prompt + every generated id,
+    /// reasoning and calls intact (`out.token_ids`, unstripped — the chat
+    /// continuation extends exactly these).
+    pub raw_log: Vec<u32>,
+    pub tools: Vec<serde_json::Value>,
+    pub thinking: bool,
+}
+
+/// Recognize `messages` as the next round of `pending`'s tool turn: the same
+/// message prefix, an assistant message echoing our calls (matched by id and
+/// function name; clients may re-serialize arguments and merge in preamble
+/// content), then `tool`-role responses answering exactly those calls. Returns
+/// the response texts in OUR call order, or `None` (caller falls back to the
+/// re-render path — recognition must never turn a valid request into an error).
+pub(crate) fn match_tool_continuation(
+    pending: &PendingToolTurn,
+    messages: &[serde_json::Value],
+    tools: &[serde_json::Value],
+    thinking: bool,
+) -> Option<Vec<(String, String)>> {
+    let n = pending.messages.len();
+    if thinking != pending.thinking
+        || tools != pending.tools.as_slice()
+        || messages.len() < n + 2
+        || messages[..n] != pending.messages[..]
+    {
+        return None;
+    }
+    let call_id = |c: &serde_json::Value| c.get("id")?.as_str().map(str::to_string);
+    let call_name =
+        |c: &serde_json::Value| c.get("function")?.get("name")?.as_str().map(str::to_string);
+    let assistant = &messages[n];
+    if assistant.get("role").and_then(serde_json::Value::as_str) != Some("assistant") {
+        return None;
+    }
+    let echoed = assistant
+        .get("tool_calls")
+        .and_then(serde_json::Value::as_array)?;
+    if echoed.len() != pending.tool_calls.len() {
+        return None;
+    }
+    for (ours, theirs) in pending.tool_calls.iter().zip(echoed) {
+        if call_id(ours) != call_id(theirs) || call_name(ours) != call_name(theirs) {
+            return None;
+        }
+    }
+    let responses = &messages[n + 1..];
+    if !responses
+        .iter()
+        .all(|m| m.get("role").and_then(serde_json::Value::as_str) == Some("tool"))
+    {
+        return None;
+    }
+    // Every call answered exactly once: match responses by `tool_call_id`, or
+    // by position when ids are absent and the counts line up.
+    let by_id: std::collections::HashMap<String, &serde_json::Value> = responses
+        .iter()
+        .filter_map(|m| Some((m.get("tool_call_id")?.as_str()?.to_string(), m)))
+        .collect();
+    let ordered: Vec<&serde_json::Value> = if by_id.len() == responses.len() {
+        if by_id.len() != pending.tool_calls.len() {
+            return None;
+        }
+        pending
+            .tool_calls
+            .iter()
+            .map(|c| by_id.get(&call_id(c)?).copied())
+            .collect::<Option<_>>()?
+    } else if responses.len() == pending.tool_calls.len() {
+        responses.iter().collect()
+    } else {
+        return None;
+    };
+    Some(
+        ordered
+            .iter()
+            .zip(&pending.tool_calls)
+            .map(|(m, c)| {
+                (
+                    call_name(c).unwrap_or_default(),
+                    crate::tools::message_text(m),
+                )
+            })
+            .collect(),
+    )
+}
+
+// ===========================================================================
 // GPU worker: owns the session, drains the job queue one at a time.
 // ===========================================================================
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -632,3 +632,111 @@ fn paced_stream_tool_call_disables_pacing() {
         "pace_off must persist: {out:?}"
     );
 }
+
+/// A tool round whose prompt seeds the thought OPEN (`start_in_thought`):
+/// the leading ids are reasoning even with no open marker in the stream, and
+/// content starts after the model's `<channel|>`.
+#[test]
+fn start_in_thought_classifies_leading_ids_as_reasoning() {
+    let close = 2u32;
+    let mut m = DiffusionStreamMapper::new(
+        FakeDecoder,
+        vec![],
+        Some(1),
+        Some(close),
+        None,
+        false,
+        true,
+        false,
+        false,
+    )
+    .starting_in_thought();
+    let canvas = [c('p'), c('l'), c('a'), c('n'), close, c('O'), c('k')];
+    let _ = m.on_step(&step(1, 2, &canvas, true));
+    assert_eq!(m.reasoning(), "plan");
+    assert_eq!(m.content(), "Ok");
+}
+
+fn pending_fixture() -> PendingToolTurn {
+    let messages = vec![serde_json::json!({"role": "user", "content": "list the files"})];
+    let tool_calls = vec![
+        serde_json::json!({"index": 0, "id": "call_0", "type": "function",
+            "function": {"name": "ls", "arguments": "{\"path\":\".\"}"}}),
+        serde_json::json!({"index": 1, "id": "call_1", "type": "function",
+            "function": {"name": "read", "arguments": "{\"path\":\"a\"}"}}),
+    ];
+    PendingToolTurn {
+        messages,
+        tool_calls,
+        raw_log: vec![1, 2, 3],
+        tools: vec![serde_json::json!({"type": "function", "function": {"name": "ls"}})],
+        thinking: true,
+    }
+}
+
+fn continuation_messages(p: &PendingToolTurn) -> Vec<serde_json::Value> {
+    let mut m = p.messages.clone();
+    m.push(serde_json::json!({
+        "role": "assistant", "content": "",
+        "tool_calls": p.tool_calls.clone(),
+    }));
+    m.push(serde_json::json!({
+        "role": "tool", "tool_call_id": "call_1", "name": "read", "content": "aaa"
+    }));
+    m.push(serde_json::json!({
+        "role": "tool", "tool_call_id": "call_0", "name": "ls", "content": "a b"
+    }));
+    m
+}
+
+#[test]
+fn continuation_matches_and_orders_responses_by_call() {
+    let p = pending_fixture();
+    let msgs = continuation_messages(&p);
+    // Responses arrive out of order; the match returns them in OUR call order.
+    let got = match_tool_continuation(&p, &msgs, &p.tools.clone(), true).unwrap();
+    assert_eq!(
+        got,
+        vec![
+            ("ls".to_string(), "a b".to_string()),
+            ("read".to_string(), "aaa".to_string()),
+        ]
+    );
+}
+
+#[test]
+fn continuation_rejects_divergence() {
+    let p = pending_fixture();
+    let msgs = continuation_messages(&p);
+    // Thinking flip, tool-set change, edited history, missing/extra responses:
+    // all fall back to the re-render path.
+    assert!(match_tool_continuation(&p, &msgs, &p.tools.clone(), false).is_none());
+    assert!(match_tool_continuation(&p, &msgs, &[], true).is_none());
+    let mut edited = msgs.clone();
+    edited[0] = serde_json::json!({"role": "user", "content": "different"});
+    assert!(match_tool_continuation(&p, &edited, &p.tools.clone(), true).is_none());
+    let missing = &msgs[..msgs.len() - 1];
+    assert!(match_tool_continuation(&p, missing, &p.tools.clone(), true).is_none());
+    let mut extra = msgs.clone();
+    extra.push(serde_json::json!({"role": "user", "content": "and now this"}));
+    assert!(match_tool_continuation(&p, &extra, &p.tools.clone(), true).is_none());
+    // A response answering an unknown call id.
+    let mut wrong = msgs.clone();
+    wrong[2]["tool_call_id"] = serde_json::json!("call_9");
+    assert!(match_tool_continuation(&p, &wrong, &p.tools.clone(), true).is_none());
+}
+
+#[test]
+fn continuation_matches_by_position_without_ids() {
+    let p = pending_fixture();
+    let mut msgs = p.messages.clone();
+    msgs.push(serde_json::json!({
+        "role": "assistant", "content": "",
+        "tool_calls": p.tool_calls.clone(),
+    }));
+    msgs.push(serde_json::json!({"role": "tool", "name": "ls", "content": "a b"}));
+    msgs.push(serde_json::json!({"role": "tool", "name": "read", "content": "aaa"}));
+    let got = match_tool_continuation(&p, &msgs, &p.tools.clone(), true).unwrap();
+    assert_eq!(got[0].0, "ls");
+    assert_eq!(got[1].1, "aaa");
+}

--- a/src/server/wire.rs
+++ b/src/server/wire.rs
@@ -35,6 +35,11 @@ pub struct DiffusionStreamMapper<D: TextDecoder> {
     channels: ChannelIds,
     thinking: bool,
     emit_drafts: bool,
+    /// The generation begins inside an already-open thought channel whose
+    /// open marker was in the prompt (a tool round's forced-open thought).
+    /// The split must classify the leading ids as reasoning even though no
+    /// open marker appears in the stream.
+    start_in_thought: bool,
 
     /// Block-committed token ids accumulated across all committed blocks.
     committed_ids: Vec<u32>,
@@ -93,6 +98,7 @@ impl<D: TextDecoder> DiffusionStreamMapper<D> {
             },
             thinking,
             emit_drafts,
+            start_in_thought: false,
             committed_ids: Vec::new(),
             emitted_reasoning: String::new(),
             emitted_content: String::new(),
@@ -104,6 +110,14 @@ impl<D: TextDecoder> DiffusionStreamMapper<D> {
             est_block_steps: 16.0,
             pace_off: false,
         }
+    }
+
+    /// The generation begins inside an already-open thought (the open marker
+    /// was in the prompt). Only meaningful with `thinking` on — the forced
+    /// opener is never seeded on a thinking-off request.
+    pub fn starting_in_thought(mut self) -> Self {
+        self.start_in_thought = true;
+        self
     }
 
     /// Committed (immutable) answer text emitted so far.
@@ -131,7 +145,9 @@ impl<D: TextDecoder> DiffusionStreamMapper<D> {
                 content: self.decode_content(ids),
             };
         }
-        let split = self.channels.split(&self.decoder, ids, false);
+        let split = self
+            .channels
+            .split(&self.decoder, ids, self.start_in_thought);
         Split {
             reasoning: self.clean_reasoning(&split.reasoning),
             content: self.decode_content(&split.content),

--- a/src/server/worker.rs
+++ b/src/server/worker.rs
@@ -24,19 +24,31 @@ impl Worker {
     /// neutralized. Returns (token ids, neutralized count, guarded render) —
     /// callers decide whether to log the count (the sizing closure renders in
     /// a loop and stays silent).
+    ///
+    /// `force_thought` (generation prompts on thinking requests): seed the
+    /// thought channel OPEN at the end of the prompt. Left to open the
+    /// channel itself, the model often narrates its plan into the visible
+    /// answer instead — beginning in-thought pins the reasoning to the
+    /// thought block. Skipped when the render ends mid-grammar in an open
+    /// `<|tool_response>` (an unanswered call the client posted back without
+    /// responses).
     fn render_prompt(
         &self,
         messages: &[serde_json::Value],
         tools: &[serde_json::Value],
         add_generation_prompt: bool,
         thinking: bool,
+        force_thought: bool,
     ) -> (Vec<u32>, usize, String) {
-        let g = crate::tools::render_conversation_guarded(
+        let mut g = crate::tools::render_conversation_guarded(
             messages,
             tools,
             add_generation_prompt,
             thinking,
         );
+        if force_thought && !g.ends_with("<|tool_response>") {
+            g.push_str("<|channel>thought\n");
+        }
         let (ids, neutralized) = self.tokenizer.encode_prompt(&g);
         (ids, neutralized, g)
     }
@@ -131,8 +143,12 @@ impl Worker {
         if ready.send(Ok(())).is_err() {
             return;
         }
+        // The most recent tool turn answered with tool calls (single slot: a
+        // second interleaved tool conversation replaces it and the displaced
+        // one falls back to the re-render path — a reuse cost, never an error).
+        let mut pending: Option<PendingToolTurn> = None;
         for job in jobs {
-            self.handle(&*stage, tool_store.as_mut(), job);
+            self.handle(&*stage, tool_store.as_mut(), &mut pending, job);
         }
     }
 
@@ -140,6 +156,7 @@ impl Worker {
         &self,
         stage: &dyn crate::pipeline::PipelineStage,
         store: Option<&mut crate::toolcompact::ToolOutputStore>,
+        pending: &mut Option<PendingToolTurn>,
         job: Job,
     ) {
         use crate::pipeline::{PipelineEvent, PipelineOp};
@@ -151,11 +168,60 @@ impl Worker {
         // Plain turns for the non-tool prompt/finalize path (gate-validated).
         let history = build_turns(&job.messages);
 
-        let (prompt, prompt_text) = if tool_mode {
+        // Continuation round of the turn we just answered with tool calls?
+        // Prompt with the model's own tokens verbatim — reasoning and calls
+        // intact — plus the responses in call order and a reopened thought,
+        // instead of the re-render that strips the reasoning and had the
+        // model re-planning from scratch every round. Also a pure KV
+        // extension: last round finalized the raw log as the routing log.
+        let continuation_on = crate::flags::serve_tool_continuation_enabled();
+        let continued = (tool_mode && continuation_on)
+            .then(|| {
+                let p = pending.as_ref()?;
+                let responses =
+                    match_tool_continuation(p, &job.messages, &job.tools, thinking)?;
+                let mut tail = String::new();
+                for (name, content) in &responses {
+                    tail.push_str(&crate::tools::render_tool_response_guarded(
+                        name,
+                        &serde_json::json!({ "content": content }),
+                    ));
+                }
+                if thinking {
+                    tail.push_str("<|channel>thought\n");
+                }
+                let (tail_ids, neutralized) = self.tokenizer.encode_prompt(&tail);
+                let mut ids = p.raw_log.clone();
+                ids.extend(tail_ids);
+                // The raw log carries the turn's reasoning, so it outgrows the
+                // thought-free re-render — when it no longer fits, fall back
+                // rather than failing a request the re-render could serve.
+                if ids.len() + crate::metal::CANVAS >= self.max_seq {
+                    eprintln!(
+                        "serve: tool continuation ({} tok) would overflow the context; re-rendering",
+                        ids.len()
+                    );
+                    return None;
+                }
+                log_neutralized(neutralized);
+                eprintln!(
+                    "serve: tool continuation ({} response(s) extend the {}-token turn log)",
+                    responses.len(),
+                    p.raw_log.len(),
+                );
+                Some(ids)
+            })
+            .flatten();
+        let was_continuation = continued.is_some();
+        let (prompt, prompt_text, start_in_thought) = if let Some(ids) = continued {
+            let text = self.tokenizer.decode(&ids);
+            (ids, text, thinking)
+        } else if tool_mode {
             let (ids, neutralized, g) =
-                self.render_prompt(&job.messages, &job.tools, true, thinking);
+                self.render_prompt(&job.messages, &job.tools, true, thinking, thinking);
             log_neutralized(neutralized);
-            (ids, crate::tools::strip_client_guards(&g))
+            let started = g.ends_with("<|channel>thought\n");
+            (ids, crate::tools::strip_client_guards(&g), started)
         } else {
             let opts = crate::chat_template::ChatFormatOptions {
                 add_generation_prompt: true,
@@ -164,7 +230,7 @@ impl Worker {
             match crate::chat_template::format_chat_token_ids(&self.tokenizer, &history, &opts) {
                 Ok(ids) => {
                     let s = self.tokenizer.decode(&ids);
-                    (ids, s)
+                    (ids, s, false)
                 }
                 Err(err) => {
                     let _ = job.resp.send(ServerEvent::Error(format!("prompt: {err}")));
@@ -187,7 +253,7 @@ impl Worker {
         }
 
         let mut cfg = self.per_request_cfg(&job, budget);
-        let mapper = self.make_mapper(&job);
+        let mapper = self.make_mapper(&job, start_in_thought);
         let log_seq = self.allocate_log_seq();
         let file_block = Arc::new(AtomicUsize::new(0));
         self.attach_block_commit_logger(&mut cfg, log_seq, &file_block);
@@ -306,10 +372,21 @@ impl Worker {
                             calls = salvage;
                         }
                     }
-                    (
-                        crate::tools::content_before_tool_calls(&raw_text),
-                        crate::tools::to_openai_tool_calls(&calls),
-                    )
+                    let mut content = crate::tools::content_before_tool_calls(&raw_text);
+                    // Final round whose forced-open thought never closed: the
+                    // model stated its answer inside the monologue (all of it
+                    // classified as reasoning) — salvage the tail rather than
+                    // replying with nothing.
+                    if calls.is_empty()
+                        && start_in_thought
+                        && content.trim().is_empty()
+                        && !reasoning.trim().is_empty()
+                    {
+                        content = crate::chat_template::sanitize_model_reply(
+                            &crate::chat::salvage_answer(&reasoning),
+                        );
+                    }
+                    (content, crate::tools::to_openai_tool_calls(&calls))
                 } else {
                     (raw_text.clone(), Vec::new())
                 };
@@ -327,6 +404,7 @@ impl Worker {
                         "ts_unix_ms": now_ms(),
                         "tool_mode": tool_mode,
                         "tool_compact": false,
+                        "continuation": was_continuation,
                         "seed": job.seed,
                         "max_tokens": job.max_tokens,
                         "messages": &job.messages,
@@ -407,7 +485,22 @@ impl Worker {
                 // clean prefix of the next turn's prompt (reasoning never persists;
                 // reuse survives a swap). Tool turns re-derive the assistant message
                 // WITH its tool_calls via the tool-aware renderer.
-                let canonical = if tool_mode {
+                let canonical = if tool_mode && continuation_on && !tool_calls.is_empty() {
+                    // The turn continues: finalize the RAW log — reasoning
+                    // intact — as the routing log, so the next round's
+                    // continuation prompt is a pure KV extension (a no-op
+                    // rebuild: the raw log IS the resident state). Thought
+                    // eviction is deferred to the round that ends the turn,
+                    // which finalizes thought-free below as always.
+                    *pending = Some(PendingToolTurn {
+                        messages: job.messages.clone(),
+                        tool_calls: tool_calls.clone(),
+                        raw_log: out.token_ids.clone(),
+                        tools: job.tools.clone(),
+                        thinking,
+                    });
+                    Some(out.token_ids.clone())
+                } else if tool_mode {
                     let mut completed = job.messages.clone();
                     // KV-reuse-first: a tool-calling turn's trailing prose
                     // renders AFTER the (future) tool responses in the
@@ -426,8 +519,11 @@ impl Worker {
                         assistant["tool_calls"] = serde_json::Value::Array(tool_calls.clone());
                     }
                     completed.push(assistant);
+                    // Turn over (or continuation off): reasoning is evicted
+                    // here, and any pending continuation state is stale.
+                    *pending = None;
                     Some(
-                        self.render_prompt(&completed, &job.tools, false, thinking)
+                        self.render_prompt(&completed, &job.tools, false, thinking, false)
                             .0,
                     )
                 } else {
@@ -493,9 +589,12 @@ impl Worker {
         cfg
     }
 
-    fn make_mapper(&self, job: &Job) -> ServeMapper {
+    /// `start_in_thought`: the prompt seeds an open thought (forced-open tool
+    /// round / continuation), so the split must classify the leading ids as
+    /// reasoning even with no open marker in the stream.
+    fn make_mapper(&self, job: &Job, start_in_thought: bool) -> ServeMapper {
         let tool_mode = needs_tool_rendering(&job.messages, &job.tools);
-        Arc::new(Mutex::new(DiffusionStreamMapper::new(
+        let mut mapper = DiffusionStreamMapper::new(
             Arc::clone(&self.tokenizer),
             self.stop_token_ids.clone(),
             self.channel_open,
@@ -510,7 +609,11 @@ impl Worker {
             job.enable_thinking,
             job.emit_drafts,
             crate::flags::paced_stream_enabled(),
-        )))
+        );
+        if start_in_thought {
+            mapper = mapper.starting_in_thought();
+        }
+        Arc::new(Mutex::new(mapper))
     }
 
     /// Tool-mode request with compaction on (the KV rewinder). Over-threshold
@@ -552,7 +655,7 @@ impl Worker {
         let routing_messages = substitute(store, &job.messages);
         let routing_prompt = {
             let (ids, neutralized, _) =
-                self.render_prompt(&routing_messages, &tools_aug, true, thinking);
+                self.render_prompt(&routing_messages, &tools_aug, true, thinking, thinking);
             log_neutralized(neutralized);
             ids
         };
@@ -593,7 +696,11 @@ impl Worker {
             let too_big = |ctx: &[serde_json::Value]| {
                 // NOTE: thinking=false here where siblings pass the request
                 // flag — preserved as-is (sizing-only render).
-                self.render_prompt(ctx, &tools_aug, true, false).0.len() + canvas + 64
+                self.render_prompt(ctx, &tools_aug, true, false, false)
+                    .0
+                    .len()
+                    + canvas
+                    + 64
                     > self.max_seq
             };
             if too_big(&ctx) {
@@ -642,7 +749,9 @@ impl Worker {
         // routing render IS the main prompt — skip the duplicate render+encode.
         let (messages_sub, prompt) = if summarized_any {
             let msgs = substitute(store, &job.messages);
-            let p = self.render_prompt(&msgs, &tools_aug, true, thinking).0;
+            let p = self
+                .render_prompt(&msgs, &tools_aug, true, thinking, thinking)
+                .0;
             (msgs, p)
         } else {
             (routing_messages, routing_prompt)
@@ -687,8 +796,10 @@ impl Worker {
             }
             // Fresh mapper per round: block indices restart at 1 on every
             // generation, and a prior round's stop token must not eat this
-            // round's text.
-            let mapper = self.make_mapper(&job);
+            // round's text. Every round's prompt seeds an open thought when
+            // thinking (the main prompt's forced opener / the expand tail's
+            // reopened one).
+            let mapper = self.make_mapper(&job, thinking);
             attach_stream_observer(&mut cfg, &mapper, &job.resp, true, true, None);
             self.attach_block_commit_logger(&mut cfg, log_seq, &file_block);
 
@@ -788,6 +899,11 @@ impl Worker {
                     tc::EXPAND_TOOL_NAME,
                     &serde_json::json!({ "content": excerpt }),
                 ));
+            }
+            // Reopen the thought for the next round (mirrors the forced-open
+            // opener every tool-mode generation prompt now carries).
+            if thinking {
+                resp_text.push_str("<|channel>thought\n");
             }
             let mut ext = out.token_ids.clone();
             ext.extend(self.tokenizer.encode_prompt(&resp_text).0);


### PR DESCRIPTION
Ports the chat tool-loop reasoning fixes (#4 / `2b49c1a`, `c9c1bae`) to the OpenAI-compatible HTTP server's client-driven tool loop.

## What changed

**Forced-open thought in tool mode.** Every tool-mode generation prompt with thinking enabled now seeds `<|channel>thought` open at the end of the prompt (skipped when the render ends in an open `<|tool_response>`), so reasoning lands in the thought block by construction instead of narrating into the visible answer. `DiffusionStreamMapper` gains `starting_in_thought()` so the wire split classifies the leading ids as reasoning even with no open marker in the stream, and a final round that never closes its thought salvages the answer from the reasoning tail instead of replying empty. The tool-compact expand loop reopens the thought after its responses the same way.

**Server-side tool-turn continuation** (the intra-turn amnesia fix). The client drives the loop over HTTP, and the thought-free re-render between rounds stripped the model's reasoning, so it re-planned from scratch every round. The worker now remembers the raw token log of the turn it just answered with tool calls (`PendingToolTurn`, single slot); a request recognized as that turn's next round (`match_tool_continuation`: same message prefix, our calls echoed by id and name, tool responses answering exactly those calls) prompts as the raw log — reasoning and calls intact — plus the rendered responses and a reopened thought.

**Registry interplay.** Mid-turn rounds finalize the raw log as the conversation's routing log (a no-op rebuild, so every round is a pure KV extension); the round that ends the turn finalizes thought-free as before, so reasoning never crosses a turn boundary and the next user turn's render stays a clean prefix. Any mismatch (edited history, changed tools, thinking flip, unanswered calls) or a continuation that would overflow the context falls back to the re-render path. `DGQ_SERVE_TOOL_CONTINUATION=0` disables.

## Verification

- **OpenCode, real task** (run tests → locate → read → edit → re-run): 5 clean rounds, zero repeated calls, correct one-shot fix; every round after the first was a continuation with full KV reuse (7041→8233 tokens resident, prefill deltas of 18–332 tokens). The baseline binary on the same task needed an extra round after a hallucinated-path edit call, and its final thought re-derived the whole history from scratch.
- **Two-turn scripted loop**: turn-end canonical drops 457→310 tokens (thought-free), the follow-up turn reuses those 310 and its own tool rounds continue cleanly.
- **`replay` of the `--log-dir` op-log**: 16 ops, 0 diverged.
- **Gates**: smoketest 17/17; new unit tests (mapper `start_in_thought`, matcher order/rejection/positional fallback); clippy + fmt clean. Golden gate not applicable (no generation-core files touched).

## Reviewer notes

- The pending slot is single-entry: two interleaved tool conversations displace each other back to the re-render path — a reuse cost, never an error (commented at the declaration).
- The continuation extends `out.token_ids` verbatim, mirroring the chat loop byte-for-byte (same `render_tool_response_guarded` + reopened-thought tail).
- ARCHITECTURE.md's KV-reuse-first serving section documents the new invariant: canonical = thought-free at turn boundaries only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)