### PR TITLE
refactor(pipeline): share the generate call-and-match; single-source serve stop-skip

### DIFF
--- a/src/chat/engine.rs
+++ b/src/chat/engine.rs
@@ -257,26 +257,6 @@ fn stats_line(tokens: usize, steps: usize, secs: f64, stopped: bool) -> String {
     )
 }
 
-/// One `PipelineOp::Generate`, unwrapped to the output or a pipeline error.
-fn pipeline_generate(
-    pipeline: &std::sync::Mutex<crate::pipeline::Pipeline>,
-    step_cfg: &metal::StepGenerateConfig,
-    prompt: Vec<u32>,
-) -> Result<crate::generate::GenerateOutput, crate::Error> {
-    match pipeline
-        .lock()
-        .unwrap()
-        .call(crate::pipeline::PipelineOp::Generate {
-            prompt,
-            cfg: Box::new(step_cfg.clone()),
-            label: "chat-tool".into(),
-        }) {
-        crate::pipeline::PipelineEvent::Generated { out, .. } => Ok(*out),
-        crate::pipeline::PipelineEvent::Error(err) => Err(crate::Error::Pipeline(err)),
-        ev => Err(crate::Error::Pipeline(format!("unexpected event {ev:?}"))),
-    }
-}
-
 /// Per-session machinery a turn borrows: the GPU pipeline, tokenizer, the
 /// mutable generation config, the tool set, and the flags that decide display.
 pub(crate) struct TurnRunner<'a> {
@@ -664,19 +644,12 @@ impl TurnRunner<'_> {
             prompt_len,
         );
         self.step_cfg.step_observer = Some(stream.observer());
-        let out = match self
-            .pipeline
-            .lock()
-            .unwrap()
-            .call(crate::pipeline::PipelineOp::Generate {
-                prompt: prompt.clone(),
-                cfg: Box::new(self.step_cfg.clone()),
-                label: "chat".into(),
-            }) {
-            crate::pipeline::PipelineEvent::Generated { out, .. } => *out,
-            crate::pipeline::PipelineEvent::Error(err) => return Err(crate::Error::Pipeline(err)),
-            ev => return Err(crate::Error::Pipeline(format!("unexpected event {ev:?}"))),
-        };
+        let out = crate::pipeline::generate(
+            &*self.pipeline.lock().unwrap(),
+            prompt.clone(),
+            Box::new(self.step_cfg.clone()),
+            "chat",
+        )?;
         self.step_cfg.step_observer = None;
         let elapsed = started.elapsed();
 
@@ -814,7 +787,12 @@ impl TurnRunner<'_> {
                 prompt_len,
             );
             self.step_cfg.step_observer = Some(stream.observer());
-            let out = pipeline_generate(self.pipeline, self.step_cfg, prompt.clone())?;
+            let out = crate::pipeline::generate(
+                &*self.pipeline.lock().unwrap(),
+                prompt.clone(),
+                Box::new(self.step_cfg.clone()),
+                "chat-tool",
+            )?;
             self.step_cfg.step_observer = None;
             let new_tokens = out.token_ids.len().saturating_sub(prompt_len);
             total_tokens += new_tokens;

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -174,19 +174,12 @@ pub fn generate_monolithic_gpu_pipeline(
         max_seq,
         gen_cfg.sampler.max_denoising_steps.max(1),
     );
-    match pipeline.call(crate::pipeline::PipelineOp::Generate {
-        prompt: prompt_token_ids.to_vec(),
-        cfg: Box::new(cfg),
-        label: prompt_label.to_string(),
-    }) {
-        crate::pipeline::PipelineEvent::Generated { out, .. } => Ok(*out),
-        crate::pipeline::PipelineEvent::Error(msg) => {
-            Err(Error::Pipeline(format!("generate: {msg}")))
-        }
-        other => Err(Error::Pipeline(format!(
-            "generate: unexpected event {other:?}"
-        ))),
-    }
+    crate::pipeline::generate(
+        &pipeline,
+        prompt_token_ids.to_vec(),
+        Box::new(cfg),
+        prompt_label,
+    )
 }
 
 #[cfg(test)]

--- a/src/pipeline/mod.rs
+++ b/src/pipeline/mod.rs
@@ -52,6 +52,26 @@ impl<S: PipelineStage + ?Sized> PipelineStage for Box<S> {
     }
 }
 
+/// One `PipelineOp::Generate`, unwrapped to its output or a pipeline error, the
+/// shared call-and-match every whole-turn generate site runs. The caller
+/// attaches any `step_observer` to `cfg` first.
+pub(crate) fn generate(
+    stage: &dyn PipelineStage,
+    prompt: Vec<u32>,
+    cfg: Box<crate::metal::StepGenerateConfig>,
+    label: &str,
+) -> Result<crate::generate::GenerateOutput, crate::Error> {
+    match stage.call(PipelineOp::Generate {
+        prompt,
+        cfg,
+        label: label.to_string(),
+    }) {
+        PipelineEvent::Generated { out, .. } => Ok(*out),
+        PipelineEvent::Error(err) => Err(crate::Error::Pipeline(err)),
+        ev => Err(crate::Error::Pipeline(format!("unexpected event {ev:?}"))),
+    }
+}
+
 /// FNV-1a over token ids (the event digest `replay` diffs against).
 pub(crate) fn ids_fnv(ids: &[u32]) -> u64 {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325;

--- a/src/server/worker.rs
+++ b/src/server/worker.rs
@@ -311,15 +311,7 @@ impl Worker {
             prefill_status,
         );
 
-        let out = match stage.call(PipelineOp::Generate {
-            prompt: prompt.clone(),
-            cfg: Box::new(cfg),
-            label: "serve".into(),
-        }) {
-            PipelineEvent::Generated { out, .. } => Ok(*out),
-            PipelineEvent::Error(err) => Err(crate::Error::Pipeline(err)),
-            ev => Err(crate::Error::Pipeline(format!("unexpected event {ev:?}"))),
-        };
+        let out = crate::pipeline::generate(stage, prompt.clone(), Box::new(cfg), "serve");
         match out {
             Ok(out) => {
                 flush_paced(&mapper, &job.resp, tool_mode);
@@ -553,6 +545,14 @@ impl Worker {
     }
 
     /// Per-request generation config shared by every serve path.
+    /// Continue-past-stop: on only under the flag and in tool mode. The engine
+    /// stop-cut and the stream mapper's quoted-stop skip both derive from this,
+    /// so they cannot drift out of lockstep.
+    fn continue_past_stop(&self, job: &Job) -> bool {
+        crate::flags::continue_past_stop_enabled()
+            && needs_tool_rendering(&job.messages, &job.tools)
+    }
+
     fn per_request_cfg(&self, job: &Job, budget: usize) -> crate::metal::StepGenerateConfig {
         let mut cfg = self.base_cfg.clone();
         cfg.sampler = crate::sample::sampler_for_steps(self.steps, self.no_early_stop);
@@ -565,11 +565,9 @@ impl Worker {
         // rescuing the call. Honor the model's stop; repair belongs to the
         // tool-repair stage (feedback + rewind), not forced continuation.
         // `DGQ_CONTINUE_PAST_STOP=1` restores the old bet.
-        cfg.continue_incomplete_tool_calls = crate::flags::continue_past_stop_enabled()
-            && needs_tool_rendering(&job.messages, &job.tools);
-        // Only read under the flag above: quoted stop ids are literal
-        // tool-arg content, not stops (mirrored by `make_mapper`'s
-        // stop_skip_quoted so stream and turn stay in lockstep).
+        cfg.continue_incomplete_tool_calls = self.continue_past_stop(job);
+        // Only read under the flag above: quoted stop ids are literal tool-arg
+        // content, not stops.
         cfg.quote_token_id = self.quote_tok;
         cfg.degenerate_reply_check =
             crate::chat_template::empty_reply_check(&self.model_dir, self.stop_token_ids.clone());
@@ -590,10 +588,7 @@ impl Worker {
                 // Quote-parity split only applies where `<|"|>` runs are
                 // grammar, which is tool mode.
                 quote: tool_mode.then_some(self.quote_tok).flatten(),
-                // Stop-skip must mirror the engine's stop policy (see
-                // `per_request_cfg`), or skipping a quoted stop the engine
-                // honors (or the reverse) would desync stream and turn.
-                stop_skip_quoted: crate::flags::continue_past_stop_enabled() && tool_mode,
+                stop_skip_quoted: self.continue_past_stop(job),
                 thinking: job.enable_thinking,
                 emit_drafts: job.emit_drafts,
                 paced: crate::flags::paced_stream_enabled(),
@@ -792,14 +787,15 @@ impl Worker {
             attach_stream_observer(&mut cfg, &mapper, &job.resp, true, true, None);
             self.attach_block_commit_logger(&mut cfg, log_seq, &file_block);
 
-            let out = match stage.call(PipelineOp::Generate {
-                prompt: round_prompt.clone(),
-                cfg: Box::new(cfg),
-                label: "serve".into(),
-            }) {
-                PipelineEvent::Generated { out, .. } => *out,
-                ev => {
-                    let _ = job.resp.send(ServerEvent::Error(format!("{ev:?}")));
+            let out = match crate::pipeline::generate(
+                stage,
+                round_prompt.clone(),
+                Box::new(cfg),
+                "serve",
+            ) {
+                Ok(out) => out,
+                Err(e) => {
+                    let _ = job.resp.send(ServerEvent::Error(format!("{e:?}")));
                     return;
                 }
             };


### PR DESCRIPTION
## What

Unify the caller-side wiring around `PipelineOp::Generate`. Pure refactor, no behavior change.

## Why

The "issue a `Generate` op, then `match Generated / Error / unexpected` to unwrap the output" ceremony was copy-pasted at five whole-turn generate sites (chat's plain and tool loops, `ask`, serve's `handle` and tool-compact round), with a chat-local `pipeline_generate` helper covering only two of them. Separately, the serve stream mapper's quoted-stop skip and the engine cfg's `continue_incomplete_tool_calls` computed the same `flag && tool_mode` expression independently, kept equal only by a comment ("mirrored ... so stream and turn stay in lockstep").

This started as an investigation into a structural `PipelineOp::GenerateStreamed` (having the pipeline own the streaming observer). Measured, that route netted *positive* — the observer bodies are irreducibly caller-specific (chat emits `ChatEvent`s to sinks; serve wraps `on_step` in dead-socket cancel, prefill heartbeat, tool-markup filtering, and channel send), so a pipeline op would add ~40-60 lines of op/event/stage surface for ~10 of caller savings. The caller-helper below is what actually removes code.

## Changes

- **`pipeline::generate(stage, prompt, cfg, label)`** — the shared call-and-match, taking `&dyn PipelineStage` so chat's `Mutex<Pipeline>`, `ask`'s bare `Pipeline`, and serve's stage chain all use it. The five sites drop their inline match; `pipeline_generate` folds in. `summarize` and `suggest` keep their inline match on purpose — a `Rewind` / a cancel-check sits between their `call` and consuming the result.
- **`Worker::continue_past_stop(job)`** — one source for `flag && needs_tool_rendering(...)`. Both `per_request_cfg` (engine stop-cut) and `make_mapper` (stream preview stop-skip) derive from it, so they can't drift.

## Verification

- **golden: 8/8 byte-identical**
- **full suite: 780 passed, 0 failed** (unchanged count — no test churn)
- clippy + fmt clean; staffeng review applied.

Net **-13 lines**. The raw line win is modest; the value is one home for the `Generated`/`Error` handling and a structural (not by-convention) tie between the two stop-cut config surfaces.
