### PR TITLE
chat: flush committed answer lines into scrollback while streaming

### DIFF
--- a/src/chat/engine.rs
+++ b/src/chat/engine.rs
@@ -638,6 +638,7 @@ impl TurnRunner<'_> {
                 prethink_seed: open_seed,
                 start_in_thought: false,
                 stream_output: self.stream_output,
+                progressive: true,
             },
             std::sync::Arc::clone(&self.sinks),
             0,
@@ -781,6 +782,9 @@ impl TurnRunner<'_> {
                     prethink_seed: think_seed.map(str::to_string),
                     start_in_thought: true,
                     stream_output: self.stream_output,
+                    // Tool rounds settle through salvage/preamble extraction
+                    // and can evaporate under repair: pane-only preview.
+                    progressive: false,
                 },
                 std::sync::Arc::clone(&self.sinks),
                 round,

--- a/src/chat/render.rs
+++ b/src/chat/render.rs
@@ -271,6 +271,15 @@ impl Viewport {
         let _ = std::io::stdout().flush();
     }
 
+    /// Print `chunk` (whole lines, each ending with a newline) at the anchor
+    /// row while the region is still active: the region scrolls it up into
+    /// real scrollback and the pane below is untouched. Only text that can
+    /// never be revised may go through here: scrollback cannot be unprinted.
+    fn flush_permanent(&self, chunk: &str) {
+        print!("\x1b[{};1H{chunk}", self.anchor);
+        let _ = std::io::stdout().flush();
+    }
+
     /// Reset the region, wipe the pane, and print `permanent` (which should end
     /// with a newline) into normal flow from the anchor, where it scrolls into
     /// real scrollback. Idempotent teardown is left to `Drop`.
@@ -292,15 +301,29 @@ impl Drop for Viewport {
     }
 }
 
-/// Terminal render state: a live preview in a reserved bottom pane plus a
-/// one-shot authoritative print at `finish`.
+/// The flushable byte cut of `text`: the end of the last complete line that
+/// is both block-committed (`committed`, from the `Text` event) and settled
+/// (`tools::settled_prefix_len`: no unclosed fence or forming tool call whose
+/// completion could re-mask earlier bytes). Text before the cut can never
+/// change, so it is safe to print into scrollback.
+fn flush_cut(text: &str, committed: usize) -> usize {
+    let committed = committed.min(text.len());
+    let settled = crate::tools::settled_prefix_len(&text[..committed]);
+    text[..settled].rfind('\n').map_or(0, |i| i + 1)
+}
+
+/// Terminal render state: a live preview in a reserved bottom pane plus an
+/// authoritative print at `finish`.
 ///
-/// The forming answer/reasoning streams into a fixed [`Viewport`] pane; the
-/// authoritative reply is printed once, at `finish`, into normal scrollback. The
-/// stream's stable prefix is speculative and can still be revised, so it is never
-/// flushed permanently — only the settled reply is. When there is no viewport
-/// (no cursor report, or a non-tty), the preview degrades to a single spinner
-/// line and the reply still prints at `finish`.
+/// The forming answer/reasoning streams into a fixed [`Viewport`] pane. The
+/// stream's stable-prefix tail is speculative and can still be revised, so it
+/// lives only in the pane. Text behind [`flush_cut`] is final, and a
+/// `progressive` turn prints those whole lines into real scrollback as they
+/// settle, keeping only the still-converging tail in the pane. `finish`
+/// prints whatever the authoritative reply adds beyond the flushed prefix
+/// (all of it, on a non-progressive turn). When there is no viewport (no
+/// cursor report, or a non-tty), the preview degrades to a single spinner
+/// line and the reply still prints whole at `finish`.
 ///
 /// Two orthogonal display toggles:
 /// - `show_thinking`: stream the reasoning (`Thought` events) grey under `think>`
@@ -322,10 +345,25 @@ struct Render {
     answer_started: bool,
     /// The reserved bottom pane, when the terminal supports it.
     viewport: Option<Viewport>,
+    /// Flush committed settled lines into scrollback mid-turn. Off for tool
+    /// rounds, whose settled text is reshaped at round end (salvage, preamble
+    /// extraction), so their preview stays pane-only.
+    progressive: bool,
+    /// Committed byte prefix of `text` (from the latest `Text` event).
+    committed: usize,
+    /// Answer bytes already printed into scrollback; always a prefix of the
+    /// `text` they were cut from, ending at a newline.
+    flushed: String,
+    /// `text` stopped extending `flushed` (a rare committed-text revision):
+    /// flushing stops and `finish` reconciles against the authoritative reply.
+    frozen: bool,
+    /// The `think>` block printed ahead of the first flushed answer line, so
+    /// `finish` prints only what the thought gained since (usually nothing).
+    thought_flushed: String,
 }
 
 impl Render {
-    fn new(show_thinking: bool, stream_output: bool, interactive: bool) -> Self {
+    fn new(show_thinking: bool, stream_output: bool, interactive: bool, progressive: bool) -> Self {
         // A multi-line preview earns a tall pane; a spinner-only turn takes one row.
         let viewport = interactive.then(|| {
             let want = if show_thinking || stream_output {
@@ -350,6 +388,11 @@ impl Render {
             thought: String::new(),
             answer_started: false,
             viewport: viewport.flatten(),
+            progressive: progressive && stream_output,
+            committed: 0,
+            flushed: String::new(),
+            frozen: false,
+            thought_flushed: String::new(),
         }
     }
 
@@ -376,8 +419,9 @@ impl Render {
                     self.thought = text.clone();
                 }
             }
-            ChatEvent::Text { text, .. } => {
+            ChatEvent::Text { committed, text } => {
                 self.answer_started = true;
+                self.committed = *committed;
                 self.text = text.clone();
             }
             _ => {}
@@ -401,7 +445,13 @@ impl Render {
         let (marker, body, color) = if reasoning {
             ("think> ", self.thought.trim(), GREY)
         } else if self.stream_output {
-            ("model> ", self.text.trim(), DIM)
+            // After a progressive flush the pane holds only the unflushed
+            // tail, markerless: it continues the flushed lines above. A
+            // frozen turn falls back to previewing the whole text.
+            match self.text.strip_prefix(self.flushed.as_str()) {
+                Some(tail) if !self.flushed.is_empty() => ("", tail.trim(), DIM),
+                _ => ("model> ", self.text.trim(), DIM),
+            }
         } else {
             return vec![self.status_line(frame)]; // answer withheld
         };
@@ -416,10 +466,47 @@ impl Render {
             .collect()
     }
 
+    /// Flush newly settled committed lines into scrollback (progressive turns
+    /// with a viewport only). The one rare failure mode, `text` no longer
+    /// extending what was flushed, freezes flushing for the turn instead of
+    /// printing a revision.
+    fn flush_committed(&mut self) {
+        if !self.progressive || self.frozen || self.viewport.is_none() || !self.answer_started {
+            return;
+        }
+        if !self.text.starts_with(self.flushed.as_str()) {
+            self.frozen = true;
+            return;
+        }
+        let cut = flush_cut(&self.text, self.committed);
+        if cut <= self.flushed.len() {
+            return;
+        }
+        let mut chunk = String::new();
+        if self.flushed.is_empty() {
+            // The settled reasoning precedes the first answer line, exactly
+            // where `finish` would have put it.
+            if self.show_thinking {
+                let t = self.thought.trim();
+                if !t.is_empty() {
+                    chunk.push_str(&format!("{GREY}think> {t}{UNDIM}\n"));
+                    self.thought_flushed = t.to_string();
+                }
+            }
+            chunk.push_str("model> ");
+        }
+        chunk.push_str(&self.text[self.flushed.len()..cut]);
+        self.flushed = self.text[..cut].to_string();
+        if let Some(vp) = &self.viewport {
+            vp.flush_permanent(&chunk);
+        }
+    }
+
     /// Repaint. Sole stdout writer during a turn.
     fn paint(&mut self) {
         let frame = SPINNER[self.spinner % SPINNER.len()];
         self.spinner = self.spinner.wrapping_add(1);
+        self.flush_committed();
         match &self.viewport {
             Some(vp) => {
                 let lines = self.preview_lines(frame, vp.n as usize, winsize().0);
@@ -437,18 +524,40 @@ impl Render {
     /// turns) above the reply, then `stats` as a trailing dim line. `reply` is
     /// the answer text (empty renders as `(empty response)`); `None` prints no
     /// `model>` line at all, for a tool-call round that only reasoned before
-    /// calling.
+    /// calling. A progressive turn already flushed a prefix of the reply (and
+    /// its `think>` block), so only the remainder prints here. An
+    /// authoritative reply that does not extend the flushed prefix (the rare
+    /// committed-text revision) reprints whole under a correction notice.
     fn finish(&mut self, reply: Option<&str>, stats: Option<&str>) {
         let mut permanent = String::new();
         if self.show_thinking {
             let t = self.thought.trim();
-            if !t.is_empty() {
+            if !t.is_empty() && self.thought_flushed.is_empty() {
                 permanent.push_str(&format!("{GREY}think> {t}{UNDIM}\n"));
+            } else if let Some(gained) = t.strip_prefix(self.thought_flushed.as_str())
+                && !gained.trim().is_empty()
+            {
+                permanent.push_str(&format!("{GREY}think> {}{UNDIM}\n", gained.trim()));
             }
         }
         match reply {
-            Some(r) if !r.is_empty() => permanent.push_str(&format!("model> {r}\n")),
-            Some(_) => permanent.push_str("model> (empty response)\n"),
+            Some(r) if self.flushed.is_empty() => {
+                if !r.is_empty() {
+                    permanent.push_str(&format!("model> {r}\n"));
+                } else {
+                    permanent.push_str("model> (empty response)\n");
+                }
+            }
+            Some(r) => match r.strip_prefix(self.flushed.as_str()) {
+                Some(rest) => {
+                    if !rest.is_empty() {
+                        permanent.push_str(&format!("{rest}\n"));
+                    }
+                }
+                None => permanent.push_str(&format!(
+                    "{DIM}(the streamed reply above was revised, final version below){UNDIM}\nmodel> {r}\n"
+                )),
+            },
             None => {}
         }
         if let Some(line) = stats {
@@ -474,7 +583,7 @@ pub fn render_demo(stage: &str) {
     }
     println!("you> demo: explain the plan");
     let _ = std::io::stdout().flush();
-    let mut r = Render::new(true, true, true);
+    let mut r = Render::new(true, true, true, true);
     r.apply(&ChatEvent::Status {
         block: 1,
         step: 1,
@@ -505,12 +614,21 @@ pub fn render_demo(stage: &str) {
             })
             .collect::<Vec<_>>()
             .join("\n");
-        r.apply(&ChatEvent::Text { committed: 0, text });
+        // All but the newest line reads as block-committed, so the demo
+        // exercises the progressive scrollback flush.
+        let committed = text.rfind('\n').map_or(0, |n| n + 1);
+        r.apply(&ChatEvent::Text { committed, text });
         r.paint();
         std::thread::sleep(Duration::from_millis(120));
     }
+    // The authoritative reply extends the streamed text (the normal case), so
+    // finish prints only the last, never-flushed line.
+    let reply = (0..6)
+        .map(|j| format!("answer line {j}: content long enough that it might overflow the pane"))
+        .collect::<Vec<_>>()
+        .join("\n");
     r.finish(
-        Some("The final settled answer, line one.\nAnd line two of the reply."),
+        Some(&reply),
         Some("(42 tok · 12 steps · 3.1s · 13.5 tok/s)"),
     );
     std::thread::sleep(Duration::from_secs(30));
@@ -554,6 +672,12 @@ pub struct StreamDisplay {
     pub start_in_thought: bool,
     /// Stream the answer as it forms (default) vs print it whole at `finish`.
     pub stream_output: bool,
+    /// Flush committed settled lines into real scrollback as the answer forms
+    /// (plain turns). Off for tool rounds: their settled text is reshaped at
+    /// round end (salvage, preamble extraction) and, under the opt-in
+    /// validator/repair stages, a whole streamed draft can evaporate. The
+    /// pane-only preview already shows those rounds streaming.
+    pub progressive: bool,
 }
 
 impl ChatStream {
@@ -580,7 +704,12 @@ impl ChatStream {
         let shared = Arc::new(Mutex::new(Shared {
             decoder,
             sinks,
-            render: Render::new(show_thinking, display.stream_output, interactive),
+            render: Render::new(
+                show_thinking,
+                display.stream_output,
+                interactive,
+                display.progressive,
+            ),
             interactive,
         }));
         {

--- a/src/tools/mod.rs
+++ b/src/tools/mod.rs
@@ -29,7 +29,9 @@ pub use parse::{
     scan_call_attempts, should_continue_past_stop, thinking_call_names, to_openai_tool_calls,
     tool_call_lost_in_thinking, validate_tool_reply,
 };
-pub(crate) use parse::{find_unmasked, masked_ranges, salvage_lost_calls, strip_thinking};
+pub(crate) use parse::{
+    find_unmasked, masked_ranges, salvage_lost_calls, settled_prefix_len, strip_thinking,
+};
 #[cfg(test)]
 pub use render::format_tool_declarations;
 #[cfg(test)]

--- a/src/tools/parse.rs
+++ b/src/tools/parse.rs
@@ -67,6 +67,57 @@ pub(crate) fn masked_ranges(text: &str) -> Vec<(usize, usize)> {
     masks
 }
 
+/// Length of the prefix of `text` whose interpretation no appended suffix can
+/// change. Both mask passes fail open on an unfinished construct (an unclosed
+/// fence is ordinary text, an unbalanced call body is no call), so a later
+/// chunk that completes the construct retroactively re-masks bytes from where
+/// it started. Everything before the earliest unfinished construct is final:
+/// masks are built left-to-right and a suffix can only start new constructs
+/// at or after it. The chat renderer uses this to decide how much
+/// block-committed text may be flushed into terminal scrollback, where it can
+/// never be revised.
+pub(crate) fn settled_prefix_len(text: &str) -> usize {
+    let mut settled = text.len();
+    // Pass-1 replica: a `call:` whose braced body never balances is a call
+    // still forming; everything from the marker on may become an arg mask.
+    let mut args: Vec<(usize, usize)> = Vec::new();
+    let mut pos = 0usize;
+    while let Some(rel) = text[pos..].find("call:") {
+        let at = pos + rel;
+        let after = &text[at + "call:".len()..];
+        let Some(brace) = after.find('{') else { break };
+        match read_braced(&after[brace..]) {
+            Some((_, consumed)) => {
+                let start = at + "call:".len() + brace;
+                args.push((start, start + consumed));
+                pos = start + consumed;
+            }
+            None => {
+                settled = settled.min(at);
+                break;
+            }
+        }
+    }
+    // Pass-2 replica (same walk as `masked_ranges`, including the straddle
+    // skip): a fence opener with no closer yet may become a mask spanning
+    // from the opener once the closing ``` arrives.
+    const FENCE: &str = "```";
+    let mut at = 0usize;
+    while let Some(open) = find_unmasked(text, &args, FENCE, at) {
+        let Some(close) = find_unmasked(text, &args, FENCE, open + FENCE.len()) else {
+            settled = settled.min(open);
+            break;
+        };
+        let end = close + FENCE.len();
+        if args.iter().any(|&(s, e)| open < s && e <= end) {
+            at = open + FENCE.len();
+            continue;
+        }
+        at = end;
+    }
+    settled
+}
+
 /// First occurrence of `needle` at/after byte `from` that does not start
 /// inside a masked range. Masks must come from `masked_ranges(text)`.
 pub(crate) fn find_unmasked(

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -597,6 +597,44 @@ fn fence_pair_cannot_swallow_a_real_call() {
 }
 
 #[test]
+fn settled_prefix_plain_and_closed_constructs_are_final() {
+    // Plain prose, a complete call, and a closed fence can never be
+    // reinterpreted by a suffix.
+    assert_eq!(settled_prefix_len("hello\nworld\n"), 12);
+    let call = "do it\ncall:edit{x:1}\ndone\n";
+    assert_eq!(settled_prefix_len(call), call.len());
+    let fenced = "before\n```rust\ncode\n```\nafter\n";
+    assert_eq!(settled_prefix_len(fenced), fenced.len());
+    // A `call:` with no brace yet is prose today and its mask, if a brace
+    // ever arrives, starts at that future brace: nothing here moves.
+    let bare = "as I said, call: me later\n";
+    assert_eq!(settled_prefix_len(bare), bare.len());
+}
+
+#[test]
+fn settled_prefix_holds_at_unfinished_constructs() {
+    // Unclosed fence: a future closer re-masks from the opener.
+    let open_fence = "safe line\n```rust\nstill streaming";
+    assert_eq!(settled_prefix_len(open_fence), 10);
+    // Unbalanced call body: a future `}` completes the arg mask at `call:`.
+    let open_call = "safe line\ncall:edit{x:<|\"|>partial";
+    assert_eq!(settled_prefix_len(open_call), 10);
+    // The earlier unfinished construct wins.
+    let both = "a\ncall:edit{open\n```\nb";
+    assert_eq!(settled_prefix_len(both), 2);
+}
+
+#[test]
+fn settled_prefix_matches_masked_ranges_straddle_walk() {
+    // The first opener's nearest closer straddles a call's args, so
+    // `masked_ranges` skips it; the next candidate opener (that closer) is
+    // then unclosed and a suffix ``` would mask from IT, not from the end.
+    let text = "``` call:edit{x:1} ``` tail";
+    let close = text.rfind("```").unwrap();
+    assert_eq!(settled_prefix_len(text), close);
+}
+
+#[test]
 fn masked_ranges_shapes() {
     // Complete call arg body masked; the call: keyword itself is not.
     let text = "call:a{x:<|\"|>v<|\"|>} tail";


### PR DESCRIPTION
## What

Chat mode now prints committed, settled lines of the forming reply straight into real scrollback as blocks commit, keeping only the still-converging tail in the ephemeral bottom pane. Previously the entire preview was speculative: it lived only in the pane, was wiped at commit, and the reply printed once at finish.

## Why it is safe now

The decoder unification made block commitment trustworthy at the token level: the stream's stop cut is the same `first_unquoted_stop` the engine's commit uses, so the ids the stream folds into its committed prefix are exactly what the engine commits. The serve wire already relies on this, streaming committed text as irreversible OpenAI content deltas.

Token commitment is not text commitment, though. `masked_ranges` fails open on unfinished constructs, so a code fence or tool-call body that closes in a later block re-masks bytes back to where it opened, revising already-committed text. The new `tools::settled_prefix_len` replicates both mask passes (including the fence straddle skip) and returns the longest prefix no appended suffix can reinterpret. The renderer's flush cut is the last newline within `min(committed, settled)`.

## Defense in depth

- If the stream ever stops extending the flushed prefix (rare committed-text revision), flushing freezes for the turn.
- At finish, the authoritative reply prints only its remainder past the flushed prefix; if it does not extend the prefix, it reprints whole under a dim correction notice. Nothing wrong can sit silently in scrollback.
- Tool rounds keep the pane-only preview (`progressive: false`): their settled text is reshaped at round end (salvage, preamble extraction) and a whole streamed draft can evaporate under the opt-in validator/repair stages.

## Mechanics

`Viewport::flush_permanent` writes at the anchor row inside the still-active scroll region, so flushed lines scroll into history while the pane keeps redrawing below. The `think>` block prints once, ahead of the first flushed answer line. The non-progressive path (non-tty, no viewport, tool rounds) is unchanged.

## Verification

- `settled_prefix_len` unit tests: pass-through, fence/call holds, and the straddle-walk edge where a suffix would mask from a skipped opener.
- `flush_cut` unit tests: newline granularity, committed clamp, fence hold and release.
- `DGQ_RENDER_DEMO=full` under tmux: each answer line lands in scrollback exactly once as it commits, finish adds only the final never-flushed line plus stats, no duplication, region teardown clean.
- Full suite green (783 tests), clippy and fmt clean, verified standalone in a detached worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
