### PR TITLE
feat(chat): paced display streaming so the reply types out

### DIFF
--- a/src/chat/engine.rs
+++ b/src/chat/engine.rs
@@ -650,6 +650,7 @@ impl TurnRunner<'_> {
                 start_in_thought: false,
                 stream_output: self.stream_output,
                 progressive: true,
+                paced: crate::flags::paced_stream_enabled(),
             },
             std::sync::Arc::clone(&self.sinks),
             0,
@@ -796,6 +797,7 @@ impl TurnRunner<'_> {
                     // Tool rounds settle through salvage/preamble extraction
                     // and can evaporate under repair: pane-only preview.
                     progressive: false,
+                    paced: crate::flags::paced_stream_enabled(),
                 },
                 std::sync::Arc::clone(&self.sinks),
                 round,

--- a/src/chat/render.rs
+++ b/src/chat/render.rs
@@ -312,6 +312,55 @@ fn flush_cut(text: &str, committed: usize) -> usize {
     text[..settled].rfind('\n').map_or(0, |i| i + 1)
 }
 
+/// Bytes to newly reveal on a paced repaint: a fraction of the backlog so a
+/// block that lands whole drains fast at first then eases in, floored and capped
+/// so the rate stays legible either way. Tuned against the ~100 ms repaint tick.
+fn reveal_step(remaining: usize) -> usize {
+    (remaining / 8).clamp(6, 40).min(remaining)
+}
+
+/// Printable characters per group, and the pause between groups, for the
+/// no-viewport typewriter below.
+const TYPE_GROUP: usize = 4;
+const TYPE_DELAY_MS: u64 = 22;
+
+/// Print `s` to stdout as if typed: printable characters in small groups with a
+/// short pause between them, ANSI escape sequences passed through whole (never
+/// split, no pause). Used when a paced turn has no reserved pane to animate, so
+/// the settled reply streams into plain scrollback instead of landing at once.
+fn type_to_scrollback(s: &str) {
+    let mut out = std::io::stdout();
+    let mut buf = String::new();
+    let mut pending = 0usize;
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        buf.push(c);
+        if c == '\x1b' {
+            // Pass the escape through atomically, up to its final letter.
+            while let Some(&n) = chars.peek() {
+                buf.push(n);
+                chars.next();
+                if n.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+            continue;
+        }
+        pending += 1;
+        if pending >= TYPE_GROUP || c == '\n' {
+            let _ = write!(out, "{buf}");
+            let _ = out.flush();
+            std::thread::sleep(Duration::from_millis(TYPE_DELAY_MS));
+            buf.clear();
+            pending = 0;
+        }
+    }
+    if !buf.is_empty() {
+        let _ = write!(out, "{buf}");
+        let _ = out.flush();
+    }
+}
+
 /// Terminal render state: a live preview in a reserved bottom pane plus an
 /// authoritative print at `finish`.
 ///
@@ -349,6 +398,14 @@ struct Render {
     /// rounds, whose settled text is reshaped at round end (salvage, preamble
     /// extraction), so their preview stays pane-only.
     progressive: bool,
+    /// Pace the display: reveal the answer at a bounded rate per repaint so it
+    /// types out smoothly even when the model lands a whole block at once (the
+    /// held tail finishes typing in `finish`). Off shows every committed byte
+    /// immediately.
+    paced: bool,
+    /// Bytes of `text` currently allowed on screen while `paced`, advanced toward
+    /// `text.len()` each repaint. Unused when pacing is off.
+    revealed: usize,
     /// Committed byte prefix of `text` (from the latest `Text` event).
     committed: usize,
     /// Answer bytes already printed into scrollback; always a prefix of the
@@ -363,7 +420,13 @@ struct Render {
 }
 
 impl Render {
-    fn new(show_thinking: bool, stream_output: bool, interactive: bool, progressive: bool) -> Self {
+    fn new(
+        show_thinking: bool,
+        stream_output: bool,
+        interactive: bool,
+        progressive: bool,
+        paced: bool,
+    ) -> Self {
         // A multi-line preview earns a tall pane; a spinner-only turn takes one row.
         let viewport = interactive.then(|| {
             let want = if show_thinking || stream_output {
@@ -389,6 +452,8 @@ impl Render {
             answer_started: false,
             viewport: viewport.flatten(),
             progressive: progressive && stream_output,
+            paced: paced && stream_output && interactive,
+            revealed: 0,
             committed: 0,
             flushed: String::new(),
             frozen: false,
@@ -423,6 +488,9 @@ impl Render {
                 self.answer_started = true;
                 self.committed = *committed;
                 self.text = text.clone();
+                // A revision may shrink the text under the reveal cursor; never
+                // let it point past the end.
+                self.revealed = self.revealed.min(self.text.len());
             }
             _ => {}
         }
@@ -433,6 +501,49 @@ impl Render {
             "{frame} thinking · block {} · step {}/{} · {}/{} locked",
             self.block, self.step, self.max_steps, self.locked, self.canvas
         )
+    }
+
+    /// The answer text currently allowed on screen: capped to the reveal cursor
+    /// while paced (so it types out), the whole of `text` otherwise.
+    fn visible(&self) -> &str {
+        if self.paced {
+            &self.text[..self.revealed.min(self.text.len())]
+        } else {
+            &self.text
+        }
+    }
+
+    /// Advance the reveal cursor one repaint's worth toward `text.len()`, snapped
+    /// up to a char boundary. A no-op unless pacing is on and text remains.
+    fn advance_reveal(&mut self) {
+        if !self.paced || self.revealed >= self.text.len() {
+            return;
+        }
+        self.revealed += reveal_step(self.text.len() - self.revealed);
+        while self.revealed < self.text.len() && !self.text.is_char_boundary(self.revealed) {
+            self.revealed += 1;
+        }
+    }
+
+    /// Type out the remainder of a paced answer before it settles: adopt the
+    /// authoritative reply (it holds the final block the stream never revealed)
+    /// and repaint at the tick cadence until the reveal cursor catches up. A
+    /// no-op unless paced with a viewport and the reply extends what streamed; a
+    /// revision falls through to `finish`'s correction path.
+    fn drain_reveal(&mut self, reply: Option<&str>) {
+        let Some(r) = reply else { return };
+        if !self.paced || self.viewport.is_none() || !r.starts_with(self.flushed.as_str()) {
+            return;
+        }
+        self.answer_started = true;
+        self.prefill = false;
+        self.text = r.to_string();
+        self.committed = r.len();
+        self.revealed = self.revealed.min(self.text.len());
+        while self.revealed < self.text.len() {
+            self.paint(); // advances the reveal cursor, then redraws
+            std::thread::sleep(Duration::from_millis(55));
+        }
     }
 
     /// The pane's content: the current phase (reasoning, answer, or a status
@@ -448,9 +559,9 @@ impl Render {
             // After a progressive flush the pane holds only the unflushed
             // tail, markerless: it continues the flushed lines above. A
             // frozen turn falls back to previewing the whole text.
-            match self.text.strip_prefix(self.flushed.as_str()) {
+            match self.visible().strip_prefix(self.flushed.as_str()) {
                 Some(tail) if !self.flushed.is_empty() => ("", tail.trim(), DIM),
-                _ => ("model> ", self.text.trim(), DIM),
+                _ => ("model> ", self.visible().trim(), DIM),
             }
         } else {
             return vec![self.status_line(frame)]; // answer withheld
@@ -478,7 +589,14 @@ impl Render {
             self.frozen = true;
             return;
         }
-        let cut = flush_cut(&self.text, self.committed);
+        // While paced, only flush whole lines the reveal cursor has reached, so
+        // scrollback fills at the same typed rate as the pane.
+        let cap = if self.paced {
+            self.revealed
+        } else {
+            self.text.len()
+        };
+        let cut = flush_cut(&self.text, self.committed.min(cap));
         if cut <= self.flushed.len() {
             return;
         }
@@ -506,6 +624,7 @@ impl Render {
     fn paint(&mut self) {
         let frame = SPINNER[self.spinner % SPINNER.len()];
         self.spinner = self.spinner.wrapping_add(1);
+        self.advance_reveal();
         self.flush_committed();
         match &self.viewport {
             Some(vp) => {
@@ -563,9 +682,21 @@ impl Render {
         if let Some(line) = stats {
             permanent.push_str(&format!("  {line}\n"));
         }
+        let paced = self.paced;
         match self.viewport.as_mut() {
             Some(vp) => vp.commit(&permanent),
-            None => print!("\r\x1b[2K{permanent}"),
+            // No reserved pane (e.g. a terminal that never answered the cursor
+            // query): a paced turn types the settled reply into scrollback
+            // instead of dropping it whole; otherwise print it at once.
+            None => {
+                print!("\r\x1b[2K");
+                let _ = std::io::stdout().flush();
+                if paced {
+                    type_to_scrollback(&permanent);
+                } else {
+                    print!("{permanent}");
+                }
+            }
         }
         let _ = std::io::stdout().flush();
     }
@@ -583,7 +714,7 @@ pub fn render_demo(stage: &str) {
     }
     println!("you> demo: explain the plan");
     let _ = std::io::stdout().flush();
-    let mut r = Render::new(true, true, true, true);
+    let mut r = Render::new(true, true, true, true, false);
     r.apply(&ChatEvent::Status {
         block: 1,
         step: 1,
@@ -678,6 +809,10 @@ pub struct StreamDisplay {
     /// validator/repair stages, a whole streamed draft can evaporate. The
     /// pane-only preview already shows those rounds streaming.
     pub progressive: bool,
+    /// Dribble each committed block's answer out over the next block's denoise so
+    /// it types out smoothly instead of landing a block at a time. Serve's paced
+    /// streaming, in the terminal.
+    pub paced: bool,
 }
 
 impl ChatStream {
@@ -697,7 +832,8 @@ impl ChatStream {
         let channels = ChannelIds::from_tokenizer(&tokenizer);
         let mut decoder = StreamDecoder::new(Arc::clone(&tokenizer), stop_token_ids)
             .with_channels(channels)
-            .with_thinking(show_thinking, display.prethink_seed);
+            .with_thinking(show_thinking, display.prethink_seed)
+            .paced(display.paced);
         if display.start_in_thought {
             decoder = decoder.starting_in_thought();
         }
@@ -709,6 +845,7 @@ impl ChatStream {
                 display.stream_output,
                 interactive,
                 display.progressive,
+                display.paced,
             ),
             interactive,
         }));
@@ -768,6 +905,8 @@ impl ChatStream {
         }
         let mut s = self.shared.lock().unwrap();
         if self.interactive {
+            // Type out any paced remainder (the held final block) before settling.
+            s.render.drain_reveal(reply);
             s.render.finish(reply, stats);
         }
     }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -47,6 +47,23 @@ pub struct StreamDecoder<D: TextDecoder> {
     /// continuation or a tool round's forced-open thought). The split classifies
     /// the leading ids as reasoning regardless of whether display is on.
     start_in_thought: bool,
+    /// Paced release: hold a finished block's committed answer and dribble it out
+    /// over the next block's denoise (a fraction of the remaining length each
+    /// step, against an EMA of block step counts) so a multi-block answer types
+    /// out smoothly instead of a whole block landing every couple of seconds. The
+    /// serve mapper does this for the wire; this is its terminal-decoder twin
+    /// (see [`super::serve`]). Off by default, enabled per turn via
+    /// [`paced`](Self::paced). The final block has no successor to pace against,
+    /// so it lands whole at `finish`.
+    paced: bool,
+    /// Bytes of the committed answer already revealed as `Text` (equal to the
+    /// committed length when pacing is off).
+    released_content: usize,
+    /// EMA of committed blocks' step counts, the pacing denominator.
+    est_block_steps: f32,
+    /// Pacing off for the rest of this turn: a tool call was committed, and an
+    /// agent consumes a tool round whole, so it must never wait on a dribble.
+    pace_off: bool,
 }
 
 impl<D: TextDecoder> StreamDecoder<D> {
@@ -63,6 +80,10 @@ impl<D: TextDecoder> StreamDecoder<D> {
             last_thought: String::new(),
             prethink_seed: None,
             start_in_thought: false,
+            paced: false,
+            released_content: 0,
+            est_block_steps: 16.0,
+            pace_off: false,
         }
     }
 
@@ -92,10 +113,85 @@ impl<D: TextDecoder> StreamDecoder<D> {
         self
     }
 
+    /// Dribble each committed block's answer out over the next block's denoise
+    /// rather than surfacing it whole, so the answer types out smoothly. Mirrors
+    /// the serve mapper's paced release ([`super::serve`]); the final block still
+    /// lands at `finish`, having no successor to pace against.
+    pub fn paced(mut self, paced: bool) -> Self {
+        self.paced = paced;
+        self
+    }
+
     /// The immutable committed reply text so far.
     #[allow(dead_code)]
     pub fn committed_text(&self) -> &str {
         &self.committed_text
+    }
+
+    /// Cap the visible answer to the paced release cursor and advance it. Unpaced
+    /// (or once a tool call is committed) this reveals the whole draft, exactly as
+    /// before. Paced, it holds a finished block and releases a step-fraction of
+    /// the remaining committed length each following step, so the previous block
+    /// finishes streaming roughly as this one commits. Returns the
+    /// `(committed_prefix_len, visible_text)` for the `Text` event.
+    fn paced_reveal(
+        &mut self,
+        committed_answer: &str,
+        draft_answer: &str,
+        ev: &StepProgressEvent<'_>,
+    ) -> (usize, String) {
+        if self.paced && !self.pace_off && committed_answer.contains("call:") {
+            self.pace_off = true;
+        }
+        if ev.block_done {
+            // The block's true length is now known; fold it into the EMA that
+            // sets how fast the next block releases this one's text.
+            self.est_block_steps = 0.5 * self.est_block_steps + 0.5 * ev.step_in_block as f32;
+        }
+        if !self.paced || self.pace_off {
+            self.released_content = committed_answer.len();
+            return (
+                common_prefix_len(committed_answer, draft_answer),
+                draft_answer.to_string(),
+            );
+        }
+        // Paced. The cursor only ever trails the committed length: a block's own
+        // finishing step holds it (nothing new to pace against yet) and the
+        // following block's steps carry it forward.
+        self.released_content = self.released_content.min(committed_answer.len());
+        if !ev.block_done {
+            let frac = (ev.step_in_block as f32 / self.est_block_steps.max(1.0)).clamp(0.0, 1.0);
+            let remaining = committed_answer.len() - self.released_content;
+            self.released_content += (remaining as f32 * frac) as usize;
+        }
+        // Snap back to a char boundary so the slice never splits a code point.
+        while self.released_content < committed_answer.len()
+            && !committed_answer.is_char_boundary(self.released_content)
+        {
+            self.released_content -= 1;
+        }
+        (
+            self.released_content,
+            committed_answer[..self.released_content].to_string(),
+        )
+    }
+
+    /// Emit a `Text` (preceded by a `Rewind` when the new text revises rather
+    /// than extends what streamed), and remember it for the next diff.
+    fn emit_text(&mut self, out: &mut Vec<ChatEvent>, committed: usize, text: String) {
+        if text == self.last_text {
+            return;
+        }
+        if !text.starts_with(&self.last_text) {
+            out.push(ChatEvent::Rewind {
+                common: common_prefix_len(&self.last_text, &text),
+            });
+        }
+        out.push(ChatEvent::Text {
+            committed,
+            text: text.clone(),
+        });
+        self.last_text = text;
     }
 
     pub fn on_step(&mut self, ev: &StepProgressEvent<'_>) -> Vec<ChatEvent> {
@@ -165,19 +261,8 @@ impl<D: TextDecoder> StreamDecoder<D> {
                 });
                 self.last_thought = thought;
             }
-            if answer != self.last_text {
-                if !answer.starts_with(&self.last_text) {
-                    out.push(ChatEvent::Rewind {
-                        common: common_prefix_len(&self.last_text, &answer),
-                    });
-                }
-                let committed = common_prefix_len(&committed_answer, &answer);
-                out.push(ChatEvent::Text {
-                    committed,
-                    text: answer.clone(),
-                });
-                self.last_text = answer;
-            }
+            let (committed, text) = self.paced_reveal(&committed_answer, &answer, ev);
+            self.emit_text(&mut out, committed, text);
             return out;
         }
 
@@ -193,29 +278,20 @@ impl<D: TextDecoder> StreamDecoder<D> {
             }
         }
 
-        // Full visible text: committed plus this block's speculative draft.
-        let mut text = self.committed_text.clone();
+        // Full visible text: the committed answer plus this block's speculative
+        // draft. Cloned up front so the paced-reveal borrow does not collide with
+        // the committed field.
+        let committed_answer = self.committed_text.clone();
+        let mut draft = committed_answer.clone();
         if !ev.block_done {
             let suffix = crate::sample::strip_degenerate_token_ids(&sp.ids);
             if !suffix.is_empty() {
-                self.decoder.decode_append(&mut text, &suffix);
-                text = crate::chat_template::sanitize_model_reply(&text);
+                self.decoder.decode_append(&mut draft, &suffix);
+                draft = crate::chat_template::sanitize_model_reply(&draft);
             }
         }
-        let committed = common_prefix_len(&self.committed_text, &text);
-
-        if text != self.last_text {
-            if !text.starts_with(&self.last_text) {
-                out.push(ChatEvent::Rewind {
-                    common: common_prefix_len(&self.last_text, &text),
-                });
-            }
-            out.push(ChatEvent::Text {
-                committed,
-                text: text.clone(),
-            });
-            self.last_text = text;
-        }
+        let (committed, text) = self.paced_reveal(&committed_answer, &draft, ev);
+        self.emit_text(&mut out, committed, text);
         out
     }
 }

--- a/src/decoder/tests.rs
+++ b/src/decoder/tests.rs
@@ -414,3 +414,47 @@ fn first_unquoted_stop_respects_quote_parity() {
     // Fully quoted block: no stop at all.
     assert_eq!(first_unquoted_stop(&[99, 99], &stops, Some(4), true), None);
 }
+
+fn ids(s: &str) -> Vec<u32> {
+    s.chars().map(|c| c as u32).collect()
+}
+
+#[test]
+fn unpaced_reveals_a_committed_block_whole() {
+    // The default (pacing off) surfaces a finished block's answer at once.
+    let mut d = StreamDecoder::new(FakeDecoder, vec![]);
+    let e = d.on_step(&step(1, 10, &ids("Hello"), true));
+    assert_eq!(texts(&e), vec!["Hello"]);
+}
+
+#[test]
+fn paced_holds_a_block_then_dribbles_it_over_the_next() {
+    let mut d = StreamDecoder::new(FakeDecoder, vec![]).paced(true);
+    // Block 1 commits "Hello", but paced holds it: nothing visible yet. This
+    // also seeds the pacing denominator (EMA of 16 and this block's 10 -> 13).
+    let e = d.on_step(&step(1, 10, &ids("Hello"), true));
+    assert_eq!(texts(&e), Vec::<&str>::new());
+    // Block 2's denoise dribbles the held text out, growing monotonically and
+    // reaching the whole block by the time this one is as long as the estimate.
+    let mid = texts(&d.on_step(&step(2, 5, &ids("!"), false)))
+        .last()
+        .unwrap()
+        .to_string();
+    assert!(!mid.is_empty() && mid.len() < 5, "partial reveal: {mid:?}");
+    assert!("Hello".starts_with(&mid), "prefix of the block: {mid:?}");
+    let full = texts(&d.on_step(&step(2, 13, &ids("!"), false)))
+        .last()
+        .unwrap()
+        .to_string();
+    // The still-speculative "!" of block 2 is not shown; only block 1's text is.
+    assert_eq!(full, "Hello");
+}
+
+#[test]
+fn paced_flushes_and_stops_once_a_tool_call_commits() {
+    // An agent consumes a tool round whole, so a committed `call:` ends pacing
+    // and surfaces the block immediately rather than dribbling it.
+    let mut d = StreamDecoder::new(FakeDecoder, vec![]).paced(true);
+    let e = d.on_step(&step(1, 8, &ids("call:{x}"), true));
+    assert_eq!(texts(&e), vec!["call:{x}"]);
+}


### PR DESCRIPTION
## What

DiffusionGemma commits a block of tokens at a time, so an answer lands in bursts and, in the terminal, pops out whole rather than streaming. This paces the *display* the way `serve` already paces the wire (`DGQ_PACED_STREAM`).

Two layers, both gated by `DGQ_PACED_STREAM` (default on, matching serve):

- **`StreamDecoder`** gains a paced release cursor mirroring the serve mapper (`decoder::serve`): a finished block's committed text dribbles out over the next block's denoise, paced by a step-fraction against an EMA of block step counts. It flushes the instant a tool call commits, since an agent consumes a tool round whole.
- **The renderer** reveals the answer at a bounded rate per repaint, and finishes the held tail either in the viewport pane (real terminals) or as a scrollback typewriter (terminals that never answered the cursor-position query, e.g. a headless recorder). The final block, having no successor to pace against, types out at `finish`.

## Why

Makes the terminal reflect what the model is doing instead of a spinner then a wall of text. Motivated by recording a demo GIF (already on `main`), but it improves any interactive session.

## Safety

Display-only — the authoritative reply is unchanged:

- `golden` 8/8 byte-identical
- `smoketest` 17/17
- 3 new `StreamDecoder` unit tests (`decoder::tests::paced_*`), full `cargo test` green, clippy/fmt clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)