### PR TITLE
feat(harness): scratch dir + HARNESS_DIR for shell harnesses

### DIFF
--- a/harness/web.json
+++ b/harness/web.json
@@ -1,6 +1,5 @@
 {
   "prompt": "You are a web browsing assistant driving a real headless browser. Work in small steps: navigate to a page, then read_page or find to see it, then click or type to act on it. Element refs come from find and reset on every navigation, so call find again after the page changes. To search the web, navigate to https://www.bing.com/search?q=your+query and read the results. The browser is normally hidden. If a page shows a human-verification challenge or login, do not try to beat it yourself: call show_browser to put the window on the user's screen, ask them to complete it there, and read the page again once they say it is done. Answer the user from what the pages actually say, quoting the relevant part, and say which page it came from. If a page is empty or unhelpful, try another route instead of retrying the same call.",
-  "prethink": "Current page: $$page$$\nThe user said: $$last$$\nPlan the next browsing step, or answer if the pages already read settle it.",
   "vars": { "page": ".web/page.txt" },
   "max_rounds": 16,
   "max_new_tokens": 8192,
@@ -11,7 +10,7 @@
       "params": [
         { "name": "url", "description": "The URL to open, e.g. https://example.com." }
       ],
-      "command": "bash web_driver.sh navigate"
+      "command": "bash \"$HARNESS_DIR/web_driver.sh\" navigate"
     },
     {
       "name": "read_page",
@@ -19,7 +18,7 @@
       "params": [
         { "name": "offset", "description": "Character offset to continue from, default 0.", "required": false }
       ],
-      "command": "bash web_driver.sh read"
+      "command": "bash \"$HARNESS_DIR/web_driver.sh\" read"
     },
     {
       "name": "find",
@@ -27,7 +26,7 @@
       "params": [
         { "name": "query", "description": "Case-insensitive filter on the element text, omit to list all.", "required": false }
       ],
-      "command": "bash web_driver.sh find"
+      "command": "bash \"$HARNESS_DIR/web_driver.sh\" find"
     },
     {
       "name": "click",
@@ -35,7 +34,7 @@
       "params": [
         { "name": "ref", "description": "The ref number, e.g. 3." }
       ],
-      "command": "bash web_driver.sh click"
+      "command": "bash \"$HARNESS_DIR/web_driver.sh\" click"
     },
     {
       "name": "type",
@@ -45,12 +44,12 @@
         { "name": "text", "description": "The text to type." },
         { "name": "submit", "description": "true to press Enter and submit after typing.", "required": false }
       ],
-      "command": "bash web_driver.sh type"
+      "command": "bash \"$HARNESS_DIR/web_driver.sh\" type"
     },
     {
       "name": "show_browser",
       "description": "Make the browser window visible on the user's screen, staying on the current page. Use when the user needs to complete a challenge or login themselves.",
-      "command": "bash web_driver.sh show"
+      "command": "bash \"$HARNESS_DIR/web_driver.sh\" show"
     },
     {
       "name": "eval",
@@ -58,7 +57,7 @@
       "params": [
         { "name": "js", "description": "The expression, e.g. document.title." }
       ],
-      "command": "bash web_driver.sh eval"
+      "command": "bash \"$HARNESS_DIR/web_driver.sh\" eval"
     }
   ]
 }

--- a/harness/web_driver.sh
+++ b/harness/web_driver.sh
@@ -23,7 +23,9 @@ set -u
 W=.web
 CHROME="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome"
 TEXT_CHUNK=3000
-IDLE_LIMIT=${WEB_IDLE_LIMIT:-300}
+# generous idle limit: only tool calls touch the activity stamp, and slow
+# generation between rounds must not get the browser reaped mid-turn
+IDLE_LIMIT=${WEB_IDLE_LIMIT:-1800}
 
 die() { echo "error: $1"; exit 0; }
 
@@ -37,12 +39,15 @@ start_watchdog() {
     (
         while sleep "$tick"; do
             alive || exit 0
-            last=$(stat -f %m "$W/last_used" 2>/dev/null || echo 0)
+            # a visible window belongs to the user, never reap it idle
+            [ -f "$W/visible" ] && continue
+            # a missing stamp means a fresh start, not an ancient one
+            last=$(stat -f %m "$W/last_used" 2>/dev/null) || continue
             [ $(( $(date +%s) - last )) -lt "$IDLE_LIMIT" ] && continue
             bash "$0" stop >/dev/null 2>&1
             exit 0
         done
-    ) &
+    ) </dev/null >/dev/null 2>&1 &
     echo $! > "$W/watchdog.pid"
 }
 
@@ -51,15 +56,20 @@ start_chrome() {
     mkfifo "$W/to" "$W/from"
     local headless="--headless"
     [ -f "$W/visible" ] && headless=""
+    # every daemon process detaches from the tool call's stdio: the engine
+    # reads the tool's stdout to EOF, so an inherited fd would hold the
+    # whole chat hostage until the daemon dies
     "$CHROME" $headless --remote-debugging-pipe --no-first-run \
         --window-size=1280,900 --user-data-dir="$W/profile" about:blank \
-        3<"$W/to" 4>"$W/from" 2>>"$W/chrome.log" &
+        3<"$W/to" 4>"$W/from" </dev/null >/dev/null 2>>"$W/chrome.log" &
     local cpid=$!
     echo "$cpid" > "$W/chrome.pid"
     # each holder keeps a FIFO end open and exits once Chrome dies
-    ( exec 3>"$W/to"; while kill -0 "$cpid" 2>/dev/null; do sleep 5; done ) &
+    ( exec 3>"$W/to"; while kill -0 "$cpid" 2>/dev/null; do sleep 5; done ) \
+        </dev/null >/dev/null 2>&1 &
     echo $! > "$W/holders.pid"
-    ( exec 3<"$W/from"; while kill -0 "$cpid" 2>/dev/null; do sleep 5; done ) &
+    ( exec 3<"$W/from"; while kill -0 "$cpid" 2>/dev/null; do sleep 5; done ) \
+        </dev/null >/dev/null 2>&1 &
     echo $! >> "$W/holders.pid"
     start_watchdog
 }
@@ -120,8 +130,9 @@ attach() {
 
 ensure() {
     mkdir -p "$W"
-    touch "$W/last_used"
+    # touch after any restart: start_chrome's shutdown clears the stamp
     alive || start_chrome
+    touch "$W/last_used"
     open_fds
     if [ -s "$W/session" ]; then
         SESSION=$(cat "$W/session")
@@ -130,16 +141,27 @@ ensure() {
     fi
 }
 
-# evaluate JS in the page and print its string value
-evaluate() {
+eval_once() {
     send Runtime.evaluate \
         "$(jq -cn --arg e "$1" '{expression:$e,returnByValue:true,awaitPromise:true}')" \
         "$SESSION"
+    wait_id "$SENT_ID" 15
+}
+
+session_dead() { printf '%s' "$1" | jq -e 'has("error")' >/dev/null 2>&1; }
+
+# evaluate JS in the page and print its string value; a dead session (the
+# user closed the tab or window) gets a fresh blank tab and one retry
+evaluate() {
     local r ex
-    r=$(wait_id "$SENT_ID" 15) || { echo "error: the page did not answer in time"; return 1; }
+    r=$(eval_once "$1") || { echo "error: the page did not answer in time"; return 1; }
+    if session_dead "$r"; then
+        attach
+        r=$(eval_once "$1") || { echo "error: the page did not answer in time"; return 1; }
+    fi
     ex=$(printf '%s' "$r" | jq -r '.result.exceptionDetails.exception.description // empty' 2>/dev/null | head -2)
     [ -z "$ex" ] || { echo "js error: $ex"; return 1; }
-    printf '%s' "$r" | jq -r '.result.result
+    printf '%s' "$r" | jq -r '(.result.result // {})
         | if has("value") then (.value | if type == "string" then . else tojson end)
           else (.type // "undefined") end'
 }
@@ -155,7 +177,8 @@ where() { echo "now at: $(cat "$W/page.txt" 2>/dev/null || echo unknown)"; }
 # JSON-encode an env var so it embeds safely in a JS expression
 jsq() { jq -cn --arg s "$1" '$s'; }
 
-FIND_JS='(()=>{const q=QJ.toLowerCase();let n=0;const out=[];
+FIND_JS='(()=>{if(location.href==="about:blank")return "(no page loaded; the browser restarted, navigate again)";
+const q=QJ.toLowerCase();let n=0;const out=[];
 const sel="a[href],button,input,textarea,select,[role=button],[role=link],[role=tab],[role=searchbox],[onclick]";
 for(const e of document.querySelectorAll(sel)){
 if(!(e.offsetParent||e.getClientRects().length))continue;
@@ -185,7 +208,8 @@ e.dispatchEvent(new KeyboardEvent("keydown",k));e.dispatchEvent(new KeyboardEven
 if(e.form){if(e.form.requestSubmit)e.form.requestSubmit();else e.form.submit()}}
 return "typed into ["+r+"]"+(s?", submitted":"")})()'
 
-READ_JS='(()=>{const o=OJ;const t=document.body?document.body.innerText:"";
+READ_JS='(()=>{if(location.href==="about:blank")return "(no page loaded; the browser restarted, navigate again)";
+const o=OJ;const t=document.body?document.body.innerText:"";
 if(!t)return "(the page has no text)";
 const chunk=t.slice(o,o+NJ).trim();
 if(!chunk)return "(offset "+o+" is past the end, the page text is "+t.length+" chars)";
@@ -193,10 +217,16 @@ return chunk+(t.length>o+NJ?"\n\n[chars "+o+".."+(o+NJ)+" of "+t.length+", call 
 
 cmd_navigate() {
     ensure
-    local u=${url:?} err
+    local u=${url:?} ack err
     case "$u" in http://*|https://*) ;; *) u="https://$u" ;; esac
     send Page.navigate "$(jq -cn --arg u "$u" '{url:$u}')" "$SESSION"
-    err=$(wait_id "$SENT_ID" 15 | jq -r '.result.errorText // empty')
+    ack=$(wait_id "$SENT_ID" 15)
+    if session_dead "$ack"; then
+        attach
+        send Page.navigate "$(jq -cn --arg u "$u" '{url:$u}')" "$SESSION"
+        ack=$(wait_id "$SENT_ID" 15)
+    fi
+    err=$(printf '%s' "$ack" | jq -r '.result.errorText // empty')
     [ -z "$err" ] || die "navigation failed: $err"
     wait_load 20 || true
     update_page
@@ -207,10 +237,16 @@ cmd_navigate() {
 
 cmd_read() {
     ensure
-    local o
+    local o out
     o=$(printf '%s' "${offset:-0}" | tr -cd '0-9')
     local js=${READ_JS//OJ/${o:-0}}
-    evaluate "${js//NJ/$TEXT_CHUNK}"
+    js=${js//NJ/$TEXT_CHUNK}
+    out=$(evaluate "$js")
+    if [ "$out" = "(the page has no text)" ]; then
+        sleep 2
+        out=$(evaluate "$js")
+    fi
+    printf '%s\n' "$out"
 }
 
 cmd_find() {
@@ -262,11 +298,23 @@ cmd_status() {
 }
 
 shutdown_chrome() {
-    [ -f "$W/chrome.pid" ] && kill "$(cat "$W/chrome.pid")" 2>/dev/null
+    local cpid=""
+    [ -f "$W/chrome.pid" ] && cpid=$(cat "$W/chrome.pid")
+    [ -n "$cpid" ] && kill "$cpid" 2>/dev/null
     [ -f "$W/holders.pid" ] && kill $(cat "$W/holders.pid") 2>/dev/null
     [ -f "$W/watchdog.pid" ] && kill "$(cat "$W/watchdog.pid")" 2>/dev/null
     rm -f "$W/chrome.pid" "$W/holders.pid" "$W/watchdog.pid" "$W/last_used" \
         "$W/session" "$W/seq" "$W/to" "$W/from"
+    # wait until the profile is released, or the next launch loses the
+    # profile-singleton race against the dying instance and quits
+    if [ -n "$cpid" ]; then
+        local i=0
+        while kill -0 "$cpid" 2>/dev/null && [ "$i" -lt 50 ]; do
+            sleep 0.2
+            i=$((i + 1))
+        done
+        kill -9 "$cpid" 2>/dev/null
+    fi
 }
 
 # restart with a visible window, back on the page we were on
@@ -277,11 +325,8 @@ cmd_show() {
         where
         return
     fi
-    local u=""
-    if alive; then
-        ensure
-        u=$(evaluate "location.href") || u=""
-    fi
+    local u
+    u=$(sed 's/.* :: //' "$W/page.txt" 2>/dev/null)
     touch "$W/visible"
     shutdown_chrome
     ensure

--- a/src/chat/engine.rs
+++ b/src/chat/engine.rs
@@ -85,6 +85,9 @@ pub(crate) struct ShellTool {
     params: Vec<ToolParam>,
     /// Working directory for `command`. None inherits the chat process cwd.
     work_dir: Option<std::path::PathBuf>,
+    /// Exported as `HARNESS_DIR`: the harness file's directory, so commands
+    /// can reference scripts shipped beside it while running in `work_dir`.
+    harness_dir: Option<std::path::PathBuf>,
 }
 
 impl ShellTool {
@@ -95,11 +98,17 @@ impl ShellTool {
             command,
             params,
             work_dir: None,
+            harness_dir: None,
         }
     }
 
-    pub fn in_dir(mut self, dir: Option<std::path::PathBuf>) -> Self {
-        self.work_dir = dir;
+    pub fn in_dirs(
+        mut self,
+        work_dir: Option<std::path::PathBuf>,
+        harness_dir: Option<std::path::PathBuf>,
+    ) -> Self {
+        self.work_dir = work_dir;
+        self.harness_dir = harness_dir;
         self
     }
 }
@@ -181,6 +190,9 @@ fn run_shell_tool(
     cmd.arg("-c").arg(&t.command);
     if let Some(dir) = &t.work_dir {
         cmd.current_dir(dir);
+    }
+    if let Some(dir) = &t.harness_dir {
+        cmd.env("HARNESS_DIR", dir);
     }
     for (k, v) in vars {
         cmd.env(format!("HARNESS_{k}"), v);
@@ -709,7 +721,8 @@ impl TurnRunner<'_> {
     }
 
     /// Tool turn: run the render/generate/run-script loop. `seed` is the raw
-    /// `/prethink` template; it expands once against this turn.
+    /// `/prethink` template, expanded per round so file-backed vars written
+    /// by tools mid-turn (the web harness's $$page$$) read current.
     fn tool_turn(
         &mut self,
         history: &[chat_template::ChatTurn],
@@ -722,8 +735,7 @@ impl TurnRunner<'_> {
         let messages = chat_turns_to_messages(&turns);
         let base =
             crate::tools::render_conversation_guarded(&messages, self.tools_json, true, true);
-        let seed = seed.map(|t| expand_thinking(t, history, system, &self.live_vars()));
-        self.tool_loop(base, seed.as_deref(), reseed, turn_idx)
+        self.tool_loop(base, seed, history, system, reseed, turn_idx)
     }
 
     /// The tool-calling loop: generate, run each backing script, feed the
@@ -733,12 +745,15 @@ impl TurnRunner<'_> {
     /// dropped them and the model re-planned from scratch every round), and
     /// each round is a pure KV extension instead of a rewind at the stripped
     /// thought. Tool calls/results still live only inside this turn: the next
-    /// user turn renders thought-free from history as always. `seed` (already
-    /// expanded) seeds round 0, every round if `reseed`.
+    /// user turn renders thought-free from history as always. `raw_seed` (the
+    /// unexpanded template) seeds round 0, every round if `reseed`, expanded
+    /// fresh at each injection so file-backed vars read current.
     fn tool_loop(
         &mut self,
         base: String,
-        seed: Option<&str>,
+        raw_seed: Option<&str>,
+        history: &[chat_template::ChatTurn],
+        system: Option<&str>,
         reseed: bool,
         turn_idx: u64,
     ) -> Result<String, crate::Error> {
@@ -748,6 +763,8 @@ impl TurnRunner<'_> {
         // `RoundStart`/`RoundEnd` events).
         let (mut total_tokens, mut total_steps) = (0usize, 0usize);
         let channels = ChannelIds::from_tokenizer(self.tokenizer);
+        let mut round_seed =
+            raw_seed.map(|t| expand_thinking(t, history, system, &self.live_vars()));
         // Force the thought OPEN in the prompt: left to open the channel
         // itself, the model often narrates its plan into the visible answer
         // instead. Beginning in-thought pins the reasoning to the thought
@@ -755,14 +772,14 @@ impl TurnRunner<'_> {
         let mut prompt = {
             let mut text = base;
             text.push_str(crate::tools::OPEN_THOUGHT);
-            if let Some(s) = seed {
+            if let Some(s) = &round_seed {
                 text.push_str(s.trim());
             }
             self.tokenizer.encode_prompt(&text).0
         };
         for round in 0..max_rounds {
             let think_seed = if round == 0 || reseed {
-                seed.map(str::trim)
+                round_seed.as_deref().map(str::trim)
             } else {
                 None
             };
@@ -979,8 +996,10 @@ impl TurnRunner<'_> {
             }
             // The chat loop always reopens the thought: a tool-mode turn reasons.
             let mut tail = crate::tools::tool_continuation_tail(&responses, true);
-            if reseed && let Some(s) = seed {
+            if reseed && let Some(t) = raw_seed {
+                let s = expand_thinking(t, history, system, &self.live_vars());
                 tail.push_str(s.trim());
+                round_seed = Some(s);
             }
             prompt = out.token_ids;
             prompt.extend(self.tokenizer.encode_prompt(&tail).0);
@@ -1243,13 +1262,13 @@ mod tests {
     }
 
     #[test]
-    fn shell_tool_runs_in_its_work_dir() {
+    fn shell_tool_runs_in_its_work_dir_with_harness_dir_env() {
         let dir = std::env::temp_dir().canonicalize().unwrap();
-        let t = parse_tool_spec("where=pwd")
+        let t = parse_tool_spec("where=printf '%s %s' \"$(pwd)\" \"$HARNESS_DIR\"")
             .unwrap()
-            .in_dir(Some(dir.clone()));
+            .in_dirs(Some(dir.clone()), Some("/tmp/h".into()));
         let out = run_shell_tool(&t, &serde_json::json!({}), &Default::default());
-        assert_eq!(std::path::PathBuf::from(out), dir);
+        assert_eq!(out, format!("{} /tmp/h", dir.display()));
     }
 
     #[test]

--- a/src/chat/harness.rs
+++ b/src/chat/harness.rs
@@ -7,8 +7,11 @@
 //! `::end` / `::set` directive lines in their output, `$$var$$` templates
 //! expand per turn, and a file-backed variable reads fresh from its file at
 //! every use so tools can buffer multi-line state there. Tool commands run
-//! from the harness file's directory, and relative var paths anchor there
-//! too, so a harness behaves the same from any invocation directory.
+//! from the harness's own scratch directory (see [`scratch_dir`]), relative
+//! var paths anchor there too, and `HARNESS_DIR` in the command environment
+//! points back at the harness file's directory for scripts shipped beside
+//! it. A harness behaves the same from any invocation directory, and its
+//! state never lands in the invoking project.
 //!
 //! ```json
 //! {
@@ -85,6 +88,26 @@ fn default_true() -> bool {
     true
 }
 
+/// The harness's scratch directory: tool commands run here and relative
+/// file vars resolve here. A tmpdir, so state is disposable, but stable
+/// across sessions until the OS cleans it. Keyed by file stem plus a hash
+/// of the absolute path so same-named harnesses stay apart.
+pub fn scratch_dir(path: &std::path::Path) -> std::path::PathBuf {
+    let abs = std::path::absolute(path).unwrap_or_else(|_| path.to_path_buf());
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for b in abs.as_os_str().as_encoded_bytes() {
+        h ^= u64::from(*b);
+        h = h.wrapping_mul(0x100_0000_01b3);
+    }
+    let stem = abs
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("harness");
+    std::env::temp_dir()
+        .join("diffgemma-harness")
+        .join(format!("{stem}-{:08x}", h & 0xffff_ffff))
+}
+
 impl Harness {
     pub fn load(path: &std::path::Path) -> Result<Harness, String> {
         let text = std::fs::read_to_string(path)
@@ -118,9 +141,13 @@ impl Harness {
         Ok(())
     }
 
-    /// The harness tools as session [`ShellTool`]s, run from `dir` (the
-    /// harness file's directory) when given.
-    pub fn shell_tools(&self, dir: Option<&std::path::Path>) -> Vec<ShellTool> {
+    /// The harness tools as session [`ShellTool`]s, run from `scratch` with
+    /// `harness_dir` exported as `HARNESS_DIR`, when given.
+    pub fn shell_tools(
+        &self,
+        scratch: Option<&std::path::Path>,
+        harness_dir: Option<&std::path::Path>,
+    ) -> Vec<ShellTool> {
         self.tools
             .iter()
             .map(|t| {
@@ -142,7 +169,10 @@ impl Harness {
                         })
                         .collect(),
                 )
-                .in_dir(dir.map(std::path::Path::to_path_buf))
+                .in_dirs(
+                    scratch.map(std::path::Path::to_path_buf),
+                    harness_dir.map(std::path::Path::to_path_buf),
+                )
             })
             .collect()
     }
@@ -178,7 +208,7 @@ mod tests {
         assert_eq!(h.prompt.as_deref(), Some("You are a narrator."));
         assert_eq!(h.vars["scene"], ".story/scene.txt");
         assert_eq!(h.max_new_tokens, Some(8192));
-        let tools = h.shell_tools(None);
+        let tools = h.shell_tools(None, None);
         assert_eq!(tools.len(), 2);
         // A no-param tool declares an empty properties object.
         let decl = crate::chat::engine::tool_declaration(&tools[1]);
@@ -192,6 +222,18 @@ mod tests {
         // A default-description tool synthesizes one; params default required.
         let decl = crate::chat::engine::tool_declaration(&tools[0]);
         assert_eq!(decl["function"]["parameters"]["required"][0], "scene");
+    }
+
+    #[test]
+    fn scratch_dirs_are_stable_and_distinct() {
+        let a = super::scratch_dir(std::path::Path::new("/proj-a/web.json"));
+        let b = super::scratch_dir(std::path::Path::new("/proj-b/web.json"));
+        assert_eq!(
+            a,
+            super::scratch_dir(std::path::Path::new("/proj-a/web.json"))
+        );
+        assert_ne!(a, b);
+        assert!(a.file_name().unwrap().to_str().unwrap().starts_with("web-"));
     }
 
     #[test]

--- a/src/commands/chat.rs
+++ b/src/commands/chat.rs
@@ -446,13 +446,29 @@ pub(crate) fn run_chat_cmd(
     };
     // A `--harness` file bundles a prompt, prethink template, file-backed
     // vars, and tools; its tools join any `--tool` definitions. Tool commands
-    // run from the harness file's directory (and relative var paths anchor
-    // there) so a harness behaves the same from any invocation directory.
-    let harness_dir = harness
-        .as_deref()
-        .and_then(|p| p.parent())
-        .filter(|d| !d.as_os_str().is_empty())
-        .map(std::path::Path::to_path_buf);
+    // run from a per-harness scratch tmpdir (relative var paths anchor there
+    // too), with HARNESS_DIR pointing back at the harness file's directory,
+    // so a harness behaves the same from any invocation directory and its
+    // state never lands in the invoking project.
+    let harness_dir = harness.as_deref().map(|p| {
+        std::path::absolute(p)
+            .unwrap_or_else(|_| p.to_path_buf())
+            .parent()
+            .map_or_else(
+                || std::path::PathBuf::from("/"),
+                std::path::Path::to_path_buf,
+            )
+    });
+    let scratch_dir = harness.as_deref().map(crate::chat::harness::scratch_dir);
+    if let Some(dir) = &scratch_dir
+        && let Err(err) = std::fs::create_dir_all(dir)
+    {
+        eprintln!(
+            "error: cannot create harness scratch {}: {err}",
+            dir.display()
+        );
+        return ExitCode::FAILURE;
+    }
     let harness = match harness.as_deref().map(crate::chat::harness::Harness::load) {
         Some(Ok(h)) => Some(h),
         Some(Err(err)) => {
@@ -462,7 +478,10 @@ pub(crate) fn run_chat_cmd(
         None => None,
     };
     if let Some(h) = &harness {
-        shell_tools.extend(h.shell_tools(harness_dir.as_deref()));
+        shell_tools.extend(h.shell_tools(scratch_dir.as_deref(), harness_dir.as_deref()));
+        if verbose && let Some(dir) = &scratch_dir {
+            eprintln!("harness scratch: {}", dir.display());
+        }
     }
     let tools_json: Vec<serde_json::Value> = shell_tools.iter().map(tool_declaration).collect();
 
@@ -644,7 +663,7 @@ pub(crate) fn run_chat_cmd(
                 h.vars
                     .iter()
                     .map(|(name, path)| {
-                        let path = match &harness_dir {
+                        let path = match &scratch_dir {
                             Some(dir) => dir.join(path),
                             None => std::path::PathBuf::from(path),
                         };
@@ -662,7 +681,15 @@ pub(crate) fn run_chat_cmd(
         let first = first.trim();
         if !first.is_empty() {
             history.push(chat_template::ChatTurn::user(first));
-            let spec = TurnSpec::resolve(PendingTurn::default(), !tools_json.is_empty());
+            // The harness prethink applies to this first turn too, matching
+            // the REPL loop's PendingTurn below.
+            let spec = TurnSpec::resolve(
+                PendingTurn {
+                    persistent_prethink: harness.as_ref().and_then(|h| h.prethink.clone()),
+                    ..PendingTurn::default()
+                },
+                !tools_json.is_empty(),
+            );
             if let Err(err) = run_turn(
                 &mut runner,
                 &mut history,

--- a/src/tools/tests.rs
+++ b/src/tools/tests.rs
@@ -194,6 +194,17 @@ fn scan_call_attempts_orders_and_flags() {
     assert_eq!(attempts[0], ("todowrite".to_string(), true));
     assert_eq!(attempts[1], ("write".to_string(), false));
     assert!(scan_call_attempts("no calls here").is_empty());
+
+    // A round truncated mid-call (seen live: generation stopped right after
+    // the opening string quote) is one invalid attempt, flagged corrupt, and
+    // the preamble excludes the fragment.
+    let cut = "I should try a travel site.<|tool_call>call:navigate{url:<|\"|>";
+    assert_eq!(scan_call_attempts(cut), [("navigate".to_string(), false)]);
+    assert!(has_incomplete_tool_call(cut));
+    assert_eq!(
+        content_before_tool_calls(cut),
+        "I should try a travel site."
+    );
 }
 
 #[test]


### PR DESCRIPTION
## What

Follow-up to the web browsing harness. Two changes to how shell harnesses run their tools:

- **Per-harness scratch dir.** Tool commands and relative file-var paths now resolve inside a disposable tmpdir keyed by the harness file's stem plus a hash of its absolute path, rather than the harness file's own directory. A harness no longer writes state (buffered `$$page$$` text, etc.) into whatever project it was launched from, and same-named harnesses in different projects stay apart.
- **`HARNESS_DIR`.** Exported into each tool command's environment, pointing at the harness file's directory, so a harness can invoke scripts shipped beside it — e.g. the web harness calling `web_driver.sh` via `$HARNESS_DIR`.

Plus: the `/prethink` seed re-expands each tool round so file-backed vars read their current contents mid-turn, and the harness prethink now applies to the first non-interactive turn (matching the REPL loop).

## Tests

`cargo test` green, including new coverage:
- `chat::harness::scratch_dirs_are_stable_and_distinct`
- `chat::engine::shell_tool_runs_in_its_work_dir_with_harness_dir_env`
- `chat::engine::shell_tool_sees_state_vars_under_harness_prefix`

## Note

This packages local WIP that predated this session; verified to build and pass its tests on top of current `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)