### PR TITLE
refactor(decoder): one canonical diffusion stream for chat and serve

### DIFF
--- a/src/decoder/core.rs
+++ b/src/decoder/core.rs
@@ -1,0 +1,223 @@
+//! The one canonical diffusion stream both the terminal and the wire consume.
+//!
+//! [`DiffusionStream`] turns the raw per-step canvas ([`StepProgressEvent`])
+//! into [`StreamEvent`]s: the [`Stabilizer`] stop-cut front end and the
+//! token-level [`ChannelIds::split`] live here once, so chat and serve stay in
+//! step on those fragile rules by consuming the same events rather than
+//! re-deriving them.
+//!
+//! Each channel's text is a two-region model. `text[..committed]` is the
+//! model-locked prefix: immutable across events but for a rare re-denoise
+//! revision (which a consumer sees as `text[..committed]` changing, and which
+//! [`WireDelta`](super::serve)/chat handle by resetting their release). Beyond
+//! it, `text[committed..]` is the still-converging draft. The stream carries the
+//! model's truth and paces nothing; how fast a consumer reveals the committed
+//! region is a display policy it applies with [`PacedRelease`](super::pace).
+
+use super::{ChannelIds, Stabilizer, StepProgressEvent, TextDecoder};
+
+/// Which side of the thought split a [`StreamEvent::Text`] carries.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Channel {
+    /// The answer (post-`<channel|>` text, or everything when thinking is off).
+    Content,
+    /// The reasoning (inside a `<|channel>...<channel|>` thought span).
+    Reasoning,
+}
+
+/// One event in the canonical stream.
+#[derive(Clone, PartialEq, Debug)]
+pub enum StreamEvent {
+    /// A new canvas block began denoising.
+    Block { block: usize },
+    /// Per-step denoise progress (the diffusion status line).
+    Progress {
+        block: usize,
+        step: u32,
+        max_steps: usize,
+        canvas: usize,
+        locked: usize,
+        accepted: u32,
+    },
+    /// A channel's text this step. `text[..committed]` is the model-locked
+    /// prefix (see the module note on the rare revision); `text[committed..]` is
+    /// the draft. Emitted whenever `(committed, text)` changes.
+    Text {
+        channel: Channel,
+        committed: usize,
+        text: String,
+    },
+    /// A block's stable ids locked into the committed stream.
+    Commit { block: usize, tokens: usize },
+    /// Generation ended (a stop token fell outside a tool call).
+    End { stopped: bool },
+}
+
+/// Special ids and thought-split behavior for a [`DiffusionStream`].
+#[derive(Default)]
+pub struct StreamConfig {
+    pub stops: Vec<u32>,
+    pub channel_open: Option<u32>,
+    pub channel_close: Option<u32>,
+    pub quote: Option<u32>,
+    pub stop_skip_quoted: bool,
+    /// Split reasoning from content. Off routes every id to `Content`.
+    pub thinking: bool,
+    /// Generation begins inside an already-open thought (a tool round's
+    /// forced-open thought, or a `/prethink` continuation).
+    pub start_in_thought: bool,
+}
+
+/// One channel's committed text and the change-detection cursor for its `Text`.
+#[derive(Default)]
+struct Chan {
+    committed: String,
+    last_committed: usize,
+    last_text: String,
+    seen: bool,
+}
+
+pub struct DiffusionStream<D: TextDecoder> {
+    decoder: D,
+    stab: Stabilizer,
+    channels: ChannelIds,
+    thinking: bool,
+    start_in_thought: bool,
+    committed_ids: Vec<u32>,
+    content: Chan,
+    reasoning: Chan,
+    ended: bool,
+}
+
+impl<D: TextDecoder> DiffusionStream<D> {
+    pub fn new(decoder: D, cfg: StreamConfig) -> Self {
+        Self {
+            decoder,
+            stab: Stabilizer::new(cfg.stops, cfg.quote, cfg.stop_skip_quoted),
+            channels: ChannelIds {
+                open: cfg.channel_open,
+                close: cfg.channel_close,
+                quote: cfg.quote,
+            },
+            thinking: cfg.thinking,
+            start_in_thought: cfg.start_in_thought,
+            committed_ids: Vec::new(),
+            content: Chan::default(),
+            reasoning: Chan::default(),
+            ended: false,
+        }
+    }
+
+    /// Post-construction config, for consumers that assemble it through a
+    /// builder chain (the chat decoder). All only affect the split, which runs
+    /// from the first step, so setting them before any `on_step` is enough.
+    pub fn set_channels(&mut self, channels: ChannelIds) {
+        self.channels = channels;
+    }
+    pub fn set_thinking(&mut self, thinking: bool) {
+        self.thinking = thinking;
+    }
+    pub fn set_start_in_thought(&mut self, start_in_thought: bool) {
+        self.start_in_thought = start_in_thought;
+    }
+
+    /// The model-locked answer text so far.
+    pub fn content(&self) -> &str {
+        &self.content.committed
+    }
+
+    /// The model-locked reasoning text so far.
+    pub fn reasoning(&self) -> &str {
+        &self.reasoning.committed
+    }
+
+    /// Split ids into `(reasoning, content)` text. Thinking off is all content.
+    fn split(&self, ids: &[u32]) -> (String, String) {
+        if !self.thinking {
+            return (String::new(), self.decoder.decode_content(ids));
+        }
+        let s = self
+            .channels
+            .split(&self.decoder, ids, self.start_in_thought);
+        (
+            self.decoder.decode_reasoning(&s.reasoning),
+            self.decoder.decode_content(&s.content),
+        )
+    }
+
+    pub fn on_step(&mut self, ev: &StepProgressEvent<'_>) -> Vec<StreamEvent> {
+        let mut out = Vec::new();
+        if self.ended {
+            return out;
+        }
+        let sp = self.stab.on_step(ev);
+        if sp.new_block {
+            out.push(StreamEvent::Block {
+                block: ev.block_idx,
+            });
+        }
+        out.push(StreamEvent::Progress {
+            block: ev.block_idx,
+            step: ev.step_in_block,
+            max_steps: ev.max_steps,
+            canvas: ev.argmax.len(),
+            locked: sp.ids.len(),
+            accepted: ev.accept_count,
+        });
+
+        // Committed + this step's speculative draft, the full per-channel text.
+        let mut all = self.committed_ids.clone();
+        all.extend_from_slice(&sp.ids);
+        let (full_reasoning, full_content) = self.split(&all);
+
+        if ev.block_done {
+            self.committed_ids.extend_from_slice(&sp.ids);
+            let (committed_reasoning, committed_content) = self.split(&self.committed_ids);
+            self.content.committed = committed_content;
+            self.reasoning.committed = committed_reasoning;
+            if sp.hit_stop && !crate::tools::should_continue_past_stop(&self.content.committed) {
+                self.ended = true;
+            }
+            out.push(StreamEvent::Commit {
+                block: ev.block_idx,
+                tokens: sp.ids.len(),
+            });
+        }
+
+        // Reasoning before content, the order both consumers expect.
+        if self.thinking {
+            emit_text(
+                &mut out,
+                Channel::Reasoning,
+                &mut self.reasoning,
+                &full_reasoning,
+            );
+        }
+        emit_text(&mut out, Channel::Content, &mut self.content, &full_content);
+        if self.ended {
+            out.push(StreamEvent::End { stopped: true });
+        }
+        out
+    }
+}
+
+/// Push a `Text` for `chan` when `(committed_len, text)` changed. `committed` is
+/// clamped into `text` and snapped to a char boundary so a slice never splits a
+/// code point.
+fn emit_text(out: &mut Vec<StreamEvent>, channel: Channel, chan: &mut Chan, text: &str) {
+    let mut committed = chan.committed.len().min(text.len());
+    while committed > 0 && !text.is_char_boundary(committed) {
+        committed -= 1;
+    }
+    if chan.seen && committed == chan.last_committed && text == chan.last_text {
+        return;
+    }
+    chan.seen = true;
+    chan.last_committed = committed;
+    chan.last_text = text.to_string();
+    out.push(StreamEvent::Text {
+        channel,
+        committed,
+        text: text.to_string(),
+    });
+}

--- a/src/decoder/mod.rs
+++ b/src/decoder/mod.rs
@@ -7,6 +7,8 @@
 //! primitives, keeping chat and serve in step on the fragile stable-prefix and
 //! channel-split rules.
 
+mod core;
+mod pace;
 mod serve;
 mod split;
 mod stabilize;
@@ -19,6 +21,8 @@ mod testutil;
 pub use serve::{DiffusionStreamMapper, MapperConfig, WireDelta};
 pub use stream::StreamDecoder;
 
+pub(crate) use core::{Channel, DiffusionStream, StreamConfig, StreamEvent};
+pub(crate) use pace::PaceClock;
 pub(crate) use split::{ChannelIds, salvage_answer};
 pub(crate) use stabilize::{Stabilizer, first_unquoted_stop};
 
@@ -52,6 +56,9 @@ pub struct StepProgressEvent<'a> {
 /// real 32 MB tokenizer.
 pub trait TextDecoder {
     fn decode(&self, ids: &[u32]) -> String;
+    /// Decode-and-append. Only test doubles build `decode` on top of this now,
+    /// but the real tokenizer impl keeps it as the natural primitive.
+    #[allow(dead_code)]
     fn decode_append(&self, out: &mut String, ids: &[u32]);
 
     /// Decode answer-side ids to sanitized visible text. Degenerate ids are

--- a/src/decoder/pace.rs
+++ b/src/decoder/pace.rs
@@ -1,0 +1,74 @@
+//! Paced release, shared by the wire mapper and the terminal decoder.
+//!
+//! The canonical stream ([`super::core`]) carries the model-committed text
+//! whole. A consumer that wants it to arrive smoothly rather than a block at a
+//! time reveals it through a [`PaceClock`]: a finished block's committed bytes
+//! dribble out over the next block's denoise, a fraction of the remainder each
+//! step against an EMA of block step counts. One clock per decoder (the block
+//! length estimate and the tool-call gate are shared); one release cursor per
+//! channel, since reasoning and content advance independently.
+
+/// The per-decoder pacing state: the block-length EMA and the tool-call gate.
+pub struct PaceClock {
+    est_block_steps: f32,
+    pace_off: bool,
+}
+
+impl PaceClock {
+    pub fn new() -> Self {
+        Self {
+            est_block_steps: 16.0,
+            pace_off: false,
+        }
+    }
+
+    /// A block committed: fold its length into the EMA that sets how fast the
+    /// next block releases this one's text, and stop pacing for good once a tool
+    /// call is in the committed answer (an agent consumes a tool round whole, so
+    /// it must never wait on a dribble).
+    pub fn on_commit(&mut self, step_in_block: u32, committed_content: &str) {
+        self.est_block_steps = 0.5 * self.est_block_steps + 0.5 * step_in_block as f32;
+        if committed_content.contains("call:") {
+            self.pace_off = true;
+        }
+    }
+
+    pub fn pace_off(&self) -> bool {
+        self.pace_off
+    }
+
+    /// Where a cursor at `released` should reach this step. Unpaced or gated,
+    /// the whole committed length; a block's own finishing step holds the cursor
+    /// (nothing new to pace against yet); otherwise a step-fraction of the
+    /// remainder. Clamped into `committed` at a char boundary, never retreating.
+    pub fn target(
+        &self,
+        paced: bool,
+        block_done: bool,
+        step_in_block: u32,
+        released: usize,
+        committed: &str,
+    ) -> usize {
+        let full = committed.len();
+        let released = released.min(full);
+        let mut t = if !paced || self.pace_off {
+            full
+        } else if block_done {
+            released
+        } else {
+            let frac = (step_in_block as f32 / self.est_block_steps.max(1.0)).clamp(0.0, 1.0);
+            released + ((full - released) as f32 * frac) as usize
+        };
+        t = t.min(full).max(released);
+        while t < full && !committed.is_char_boundary(t) {
+            t -= 1;
+        }
+        t
+    }
+}
+
+impl Default for PaceClock {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/src/decoder/serve.rs
+++ b/src/decoder/serve.rs
@@ -1,11 +1,14 @@
-//! [`DiffusionStreamMapper`]: the serve stream decoder. It turns the raw
-//! per-step canvas argmax stream into [`WireDelta`]s, splitting the thought
-//! channel from the answer and separating block-committed text from the
-//! speculative draft. No GPU, no sockets, so it is unit-tested directly. The
-//! OpenAI SSE envelope framing that consumes these deltas lives in
-//! `server::wire`.
+//! [`DiffusionStreamMapper`]: the serve adapter over the canonical
+//! [`DiffusionStream`]. It turns the stream's per-channel committed/draft
+//! [`StreamEvent`]s into [`WireDelta`]s: the committed watermark's advance
+//! becomes `Content`/`Reasoning` appends (paced through a [`PaceClock`]), the
+//! draft becomes replace-semantics `Draft`. No GPU, no sockets, so it is
+//! unit-tested directly. The OpenAI SSE envelope framing that consumes these
+//! deltas lives in `server::wire`.
 
-use super::{ChannelIds, Stabilizer, StepProgressEvent, TextDecoder};
+use super::{
+    Channel, DiffusionStream, PaceClock, StepProgressEvent, StreamConfig, StreamEvent, TextDecoder,
+};
 
 /// One streamed delta produced by the mapper, before OpenAI-envelope framing.
 #[derive(Debug, Clone, PartialEq)]
@@ -38,77 +41,52 @@ pub struct MapperConfig {
 }
 
 pub struct DiffusionStreamMapper<D: TextDecoder> {
-    decoder: D,
-    /// The shared stable-prefix front end (streak tracking, stop cut, quoted-
-    /// stop skipping), one implementation with the terminal chat decoder.
-    stab: Stabilizer,
-    /// Channel/quote special ids for the shared token-level thought split.
-    channels: ChannelIds,
-    thinking: bool,
+    stream: DiffusionStream<D>,
+    /// Paces the committed watermark's release into `Content`/`Reasoning`
+    /// appends. Everything flushes at turn end or the moment a tool call appears
+    /// in committed content, since agents consume tool turns whole.
+    clock: PaceClock,
     emit_drafts: bool,
-    /// The generation begins inside an already-open thought channel whose open
-    /// marker was in the prompt (a tool round's forced-open thought). The split
-    /// must classify the leading ids as reasoning even though no open marker
-    /// appears in the stream.
-    start_in_thought: bool,
-
-    /// Block-committed token ids accumulated across all committed blocks.
-    committed_ids: Vec<u32>,
-    /// Full committed reasoning / content text (the split of `committed_ids`).
-    /// With pacing on, deltas may lag these, while [`content`](Self::content)
-    /// and [`reasoning`](Self::reasoning) always return the full committed text.
+    paced: bool,
+    /// Full committed reasoning / content text (mirrors of the stream's, kept
+    /// for delta slicing and non-prefix-revision detection). With pacing on,
+    /// deltas lag these, while [`content`](Self::content) / [`reasoning`] return
+    /// the full committed text.
     emitted_reasoning: String,
     emitted_content: String,
+    /// Byte cursors into `emitted_reasoning` / `emitted_content` already released
+    /// as deltas (equal to the full lengths when pacing is off).
+    released_reasoning: usize,
+    released_content: usize,
     /// Last draft text emitted (dedupe replace-semantics chunks).
     last_draft: String,
     ended: bool,
-
-    /// Paced release: hold a committed block's text and dribble it out during
-    /// the next block's denoise (paced by its step progress against an EMA of
-    /// block step counts) so multi-block turns stream smoothly instead of
-    /// bursting a block every N seconds. Everything flushes at turn end or the
-    /// moment a tool call appears in committed content, since agents consume
-    /// tool turns whole and must never be delayed.
-    paced: bool,
-    /// Byte cursors into `emitted_reasoning` / `emitted_content` already
-    /// released as deltas (equal to the full lengths when pacing is off).
-    released_reasoning: usize,
-    released_content: usize,
-    /// EMA of committed blocks' step counts, the pacing denominator.
-    est_block_steps: f32,
-    /// Pacing permanently off for this turn (tool call seen).
-    pace_off: bool,
-}
-
-/// Reasoning (thought-channel) and answer text split out of a committed id list.
-struct Split {
-    reasoning: String,
-    content: String,
 }
 
 impl<D: TextDecoder> DiffusionStreamMapper<D> {
     pub fn new(decoder: D, cfg: MapperConfig) -> Self {
         Self {
-            decoder,
-            stab: Stabilizer::new(cfg.stops, cfg.quote, cfg.stop_skip_quoted),
-            channels: ChannelIds {
-                open: cfg.channel_open,
-                close: cfg.channel_close,
-                quote: cfg.quote,
-            },
-            thinking: cfg.thinking,
+            stream: DiffusionStream::new(
+                decoder,
+                StreamConfig {
+                    stops: cfg.stops,
+                    channel_open: cfg.channel_open,
+                    channel_close: cfg.channel_close,
+                    quote: cfg.quote,
+                    stop_skip_quoted: cfg.stop_skip_quoted,
+                    thinking: cfg.thinking,
+                    start_in_thought: false,
+                },
+            ),
+            clock: PaceClock::new(),
             emit_drafts: cfg.emit_drafts,
-            start_in_thought: false,
-            committed_ids: Vec::new(),
+            paced: cfg.paced,
             emitted_reasoning: String::new(),
             emitted_content: String::new(),
-            last_draft: String::new(),
-            ended: false,
-            paced: cfg.paced,
             released_reasoning: 0,
             released_content: 0,
-            est_block_steps: 16.0,
-            pace_off: false,
+            last_draft: String::new(),
+            ended: false,
         }
     }
 
@@ -116,7 +94,7 @@ impl<D: TextDecoder> DiffusionStreamMapper<D> {
     /// in the prompt). Only meaningful with `thinking` on, since the forced
     /// opener is seeded only on a thinking request.
     pub fn starting_in_thought(mut self) -> Self {
-        self.start_in_thought = true;
+        self.stream.set_start_in_thought(true);
         self
     }
 
@@ -135,140 +113,95 @@ impl<D: TextDecoder> DiffusionStreamMapper<D> {
         self.ended
     }
 
-    /// Split committed ids into (reasoning, content) via the shared token-level
-    /// walk ([`ChannelIds::split`]). With thinking off, everything is content.
-    fn split(&self, ids: &[u32]) -> Split {
-        if !self.thinking {
-            return Split {
-                reasoning: String::new(),
-                content: self.decoder.decode_content(ids),
-            };
-        }
-        let split = self
-            .channels
-            .split(&self.decoder, ids, self.start_in_thought);
-        Split {
-            reasoning: self.decoder.decode_reasoning(&split.reasoning),
-            content: self.decoder.decode_content(&split.content),
-        }
-    }
-
-    /// The current speculative answer draft: the stable-prefix answer region,
-    /// including the still-converging tail, sanitized to visible text.
-    fn draft_text(&self, stable_ids: &[u32]) -> String {
-        let mut all = self.committed_ids.clone();
-        all.extend_from_slice(stable_ids);
-        self.split(&all).content
-    }
-
     pub fn on_step(&mut self, ev: &StepProgressEvent<'_>) -> Vec<WireDelta> {
         let mut out = Vec::new();
         if self.ended {
             return out;
         }
-
-        let sp = self.stab.on_step(ev);
-        let (stable_ids, hit_stop) = (sp.ids, sp.hit_stop);
-
-        // Draft (replace-semantics), emitted every step it changes.
-        if self.emit_drafts {
-            let text = self.draft_text(&stable_ids);
-            if text != self.last_draft {
-                out.push(WireDelta::Draft {
-                    committed: self.emitted_content.len(),
-                    block: ev.block_idx,
-                    step: ev.step_in_block,
-                    text: text.clone(),
-                });
-                self.last_draft = text;
+        // The content channel's draft, emitted every step it changes.
+        for e in self.stream.on_step(ev) {
+            match e {
+                StreamEvent::Text {
+                    channel: Channel::Content,
+                    text,
+                    ..
+                } if self.emit_drafts && text != self.last_draft => {
+                    out.push(WireDelta::Draft {
+                        committed: self.emitted_content.len(),
+                        block: ev.block_idx,
+                        step: ev.step_in_block,
+                        text: text.clone(),
+                    });
+                    self.last_draft = text;
+                }
+                StreamEvent::End { .. } => self.ended = true,
+                _ => {}
             }
         }
 
-        // Commit: fold this block's stable ids into the committed stream.
-        // Unpaced (or flush conditions): emit the newly-committed text now.
-        // Paced: hold it and let the per-step release below dribble it out
-        // during the next block's denoise.
+        // Mirror the newly committed text, then pace its release into appends.
         if ev.block_done {
-            self.committed_ids.extend_from_slice(&stable_ids);
-            let split = self.split(&self.committed_ids);
+            let (reasoning, content) = (self.stream.reasoning(), self.stream.content());
             // A rare non-prefix revision invalidates the release cursors.
-            if !split.reasoning.starts_with(&self.emitted_reasoning) {
+            if !reasoning.starts_with(&self.emitted_reasoning) {
                 self.released_reasoning = 0;
             }
-            if !split.content.starts_with(&self.emitted_content) {
+            if !content.starts_with(&self.emitted_content) {
                 self.released_content = 0;
             }
-            self.emitted_reasoning = split.reasoning;
-            self.emitted_content = split.content;
-            // EMA of block step counts, the pacing denominator.
-            self.est_block_steps = 0.5 * self.est_block_steps + 0.5 * ev.step_in_block as f32;
-            // Premature stop inside an unfinished tool turn (open call, or
-            // trailing prose after a closed call): keep the mapper open.
-            if hit_stop && !crate::tools::should_continue_past_stop(&self.emitted_content) {
-                self.ended = true;
-            }
-            // Tool call in committed content: agents consume tool turns whole,
-            // so flush and stop pacing for the rest of the turn.
-            if self.emitted_content.contains("call:") {
-                self.pace_off = true;
-            }
-            if !self.paced || self.pace_off || self.ended {
-                self.release_up_to(usize::MAX, usize::MAX, &mut out);
-            }
-        } else if self.paced && !self.pace_off {
-            // Paced release: fraction of the held text proportional to this
-            // block's step progress against the estimated block length, so the
-            // previous block's text finishes streaming roughly when this block
-            // commits.
-            let frac = (ev.step_in_block as f32 / self.est_block_steps.max(1.0)).clamp(0.0, 1.0);
-            let target = |released: usize, full: usize| {
-                released + ((full - released) as f32 * frac) as usize
-            };
-            self.release_up_to(
-                target(self.released_reasoning, self.emitted_reasoning.len()),
-                target(self.released_content, self.emitted_content.len()),
-                &mut out,
-            );
+            self.emitted_reasoning = reasoning.to_string();
+            self.emitted_content = content.to_string();
+            self.clock
+                .on_commit(ev.step_in_block, &self.emitted_content);
         }
-        out
-    }
-
-    /// Emit append deltas advancing the release cursors toward the byte targets
-    /// (clamped to full length, snapped back to char boundaries).
-    fn release_up_to(
-        &mut self,
-        reasoning_target: usize,
-        content_target: usize,
-        out: &mut Vec<WireDelta>,
-    ) {
-        let cut = |s: &str, mut t: usize| -> usize {
-            t = t.min(s.len());
-            while t < s.len() && !s.is_char_boundary(t) {
-                t -= 1;
-            }
-            t
-        };
-        let rt = cut(&self.emitted_reasoning, reasoning_target);
+        // Unpaced, the cursor already caught up on the last commit, so a
+        // mid-denoise step releases nothing; the turn's end (`ended`) flushes.
+        let paced = self.paced && !self.ended;
+        let rt = self.clock.target(
+            paced,
+            ev.block_done,
+            ev.step_in_block,
+            self.released_reasoning,
+            &self.emitted_reasoning,
+        );
         if rt > self.released_reasoning {
             out.push(WireDelta::Reasoning(
                 self.emitted_reasoning[self.released_reasoning..rt].to_string(),
             ));
             self.released_reasoning = rt;
         }
-        let ct = cut(&self.emitted_content, content_target);
+        let ct = self.clock.target(
+            paced,
+            ev.block_done,
+            ev.step_in_block,
+            self.released_content,
+            &self.emitted_content,
+        );
         if ct > self.released_content {
             out.push(WireDelta::Content(
                 self.emitted_content[self.released_content..ct].to_string(),
             ));
             self.released_content = ct;
         }
+        out
     }
 
     /// Release everything still held at the end of generation, so a turn that
     /// ends without a stop token does not strand paced text.
     pub fn final_flush(&mut self) -> Vec<WireDelta> {
         let mut out = Vec::new();
-        self.release_up_to(usize::MAX, usize::MAX, &mut out);
+        if self.emitted_reasoning.len() > self.released_reasoning {
+            out.push(WireDelta::Reasoning(
+                self.emitted_reasoning[self.released_reasoning..].to_string(),
+            ));
+            self.released_reasoning = self.emitted_reasoning.len();
+        }
+        if self.emitted_content.len() > self.released_content {
+            out.push(WireDelta::Content(
+                self.emitted_content[self.released_content..].to_string(),
+            ));
+            self.released_content = self.emitted_content.len();
+        }
         out
     }
 }

--- a/src/decoder/stream.rs
+++ b/src/decoder/stream.rs
@@ -1,7 +1,14 @@
-//! [`StreamDecoder`]: the per-step canvas stream to [`ChatEvent`] mapper that
-//! drives the interactive terminal renderer.
+//! [`StreamDecoder`]: the chat adapter over the canonical [`DiffusionStream`].
+//! It turns the stream's committed/draft [`StreamEvent`]s into the renderer's
+//! [`ChatEvent`]s. Only the committed answer is paced (through a [`PaceClock`])
+//! so it types out; reasoning surfaces whole as `Thought`. The stream's
+//! `text[..committed]` never-taken-back guarantee is what the renderer flushes
+//! into scrollback.
 
-use super::{ChannelIds, Stabilizer, StepProgressEvent, TextDecoder};
+use super::{
+    Channel, ChannelIds, DiffusionStream, PaceClock, StepProgressEvent, StreamConfig, StreamEvent,
+    TextDecoder,
+};
 use crate::chat::ChatEvent;
 
 /// Longest common prefix of `a` and `b` in bytes, always a char boundary.
@@ -17,80 +24,51 @@ fn common_prefix_len(a: &str, b: &str) -> usize {
     n
 }
 
-/// Converts the raw per-step canvas argmax stream into `ChatEvent`s through a
-/// [`Stabilizer`] front end, a token-level [`ChannelIds::split`] for turns that
-/// surface their reasoning, and text diffing into `Thought`/`Text`/`Rewind`
-/// events. The committed text is rebuilt once per block, keeping per-step work
-/// at O(canvas) rather than O(total reply).
 pub struct StreamDecoder<D: TextDecoder> {
-    decoder: D,
-    channels: ChannelIds,
-    stab: Stabilizer,
-    committed_ids: Vec<u32>,
-    committed_text: String,
-    ended: bool,
-    last_text: String,
-    /// Surface the reasoning live: emit `Thought` events for the thought-channel
-    /// content and treat only the post-`<channel|>` text as the answer. Set by
-    /// `--show-thinking` and implied by a `/prethink` seed. Off by default, when
-    /// the thought is stripped silently and only the answer streams.
-    thinking_display: bool,
-    /// Last surfaced thought text, for `Thought`-event dedup.
-    last_thought: String,
-    /// Present on a `/prethink` turn, whose generation runs inside an
-    /// already-open thought channel, so the surfaced reasoning is
-    /// `seed + thought-so-far` up to the model's `<channel|>`. A plain
-    /// `--show-thinking` turn opens its own thought channel and leaves this
-    /// `None`.
-    prethink_seed: Option<String>,
-    /// Generation begins inside an already-open thought (a `/prethink`
-    /// continuation or a tool round's forced-open thought). The split classifies
-    /// the leading ids as reasoning regardless of whether display is on.
-    start_in_thought: bool,
-    /// Paced release: hold a finished block's committed answer and dribble it out
-    /// over the next block's denoise (a fraction of the remaining length each
-    /// step, against an EMA of block step counts) so a multi-block answer types
-    /// out smoothly instead of a whole block landing every couple of seconds. The
-    /// serve mapper does this for the wire; this is its terminal-decoder twin
-    /// (see [`super::serve`]). Off by default, enabled per turn via
-    /// [`paced`](Self::paced). The final block has no successor to pace against,
-    /// so it lands whole at `finish`.
+    stream: DiffusionStream<D>,
+    /// Paces the committed answer's reveal so it types out. Reasoning is not
+    /// paced; it surfaces whole.
+    clock: PaceClock,
     paced: bool,
-    /// Bytes of the committed answer already revealed as `Text` (equal to the
-    /// committed length when pacing is off).
-    released_content: usize,
-    /// EMA of committed blocks' step counts, the pacing denominator.
-    est_block_steps: f32,
-    /// Pacing off for the rest of this turn: a tool call was committed, and an
-    /// agent consumes a tool round whole, so it must never wait on a dribble.
-    pace_off: bool,
+    /// Bytes of the committed answer already revealed as `Text`.
+    released: usize,
+    /// Emit `Thought` events (`--show-thinking` / a `/prethink` seed). Off keeps
+    /// the reasoning split but discards it, streaming only the answer.
+    thinking_display: bool,
+    start_in_thought: bool,
+    /// A `/prethink` seed prepended to surfaced reasoning.
+    prethink_seed: Option<String>,
+    last_text: String,
+    last_thought: String,
+    ended: bool,
 }
 
 impl<D: TextDecoder> StreamDecoder<D> {
     pub fn new(decoder: D, stops: Vec<u32>) -> Self {
         Self {
-            decoder,
-            channels: ChannelIds::default(),
-            stab: Stabilizer::new(stops, None, false),
-            committed_ids: Vec::new(),
-            committed_text: String::new(),
-            ended: false,
-            last_text: String::new(),
-            thinking_display: false,
-            last_thought: String::new(),
-            prethink_seed: None,
-            start_in_thought: false,
+            stream: DiffusionStream::new(
+                decoder,
+                StreamConfig {
+                    stops,
+                    ..Default::default()
+                },
+            ),
+            clock: PaceClock::new(),
             paced: false,
-            released_content: 0,
-            est_block_steps: 16.0,
-            pace_off: false,
+            released: 0,
+            thinking_display: false,
+            start_in_thought: false,
+            prethink_seed: None,
+            last_text: String::new(),
+            last_thought: String::new(),
+            ended: false,
         }
     }
 
     /// Bind the model's channel/quote special ids, required for a turn that
     /// surfaces its reasoning. Without them everything streams as answer.
     pub(crate) fn with_channels(mut self, channels: ChannelIds) -> Self {
-        self.channels = channels;
+        self.stream.set_channels(channels);
         self
     }
 
@@ -102,6 +80,7 @@ impl<D: TextDecoder> StreamDecoder<D> {
         self.thinking_display = show_thinking || seed.is_some();
         self.start_in_thought = self.start_in_thought || seed.is_some();
         self.prethink_seed = seed;
+        self.sync_split();
         self
     }
 
@@ -110,13 +89,14 @@ impl<D: TextDecoder> StreamDecoder<D> {
     /// discarded unless display is on.
     pub fn starting_in_thought(mut self) -> Self {
         self.start_in_thought = true;
+        self.sync_split();
         self
     }
 
     /// Dribble each committed block's answer out over the next block's denoise
-    /// rather than surfacing it whole, so the answer types out smoothly. Mirrors
-    /// the serve mapper's paced release ([`super::serve`]); the final block still
-    /// lands at `finish`, having no successor to pace against.
+    /// rather than surfacing it whole, so the answer types out smoothly. The
+    /// final block has no successor to pace against, so it lands whole at
+    /// `finish`.
     pub fn paced(mut self, paced: bool) -> Self {
         self.paced = paced;
         self
@@ -125,73 +105,58 @@ impl<D: TextDecoder> StreamDecoder<D> {
     /// The immutable committed reply text so far.
     #[allow(dead_code)]
     pub fn committed_text(&self) -> &str {
-        &self.committed_text
+        self.stream.content()
     }
 
-    /// Cap the visible answer to the paced release cursor and advance it. Unpaced
-    /// (or once a tool call is committed) this reveals the whole draft, exactly as
-    /// before. Paced, it holds a finished block and releases a step-fraction of
-    /// the remaining committed length each following step, so the previous block
-    /// finishes streaming roughly as this one commits. Returns the
-    /// `(committed_prefix_len, visible_text)` for the `Text` event.
-    fn paced_reveal(
+    /// The stream splits reasoning out whenever the answer is displayed or the
+    /// turn began in a thought (so hidden reasoning is still separated).
+    fn sync_split(&mut self) {
+        self.stream
+            .set_thinking(self.thinking_display || self.start_in_thought);
+        self.stream.set_start_in_thought(self.start_in_thought);
+    }
+
+    /// Reveal the committed answer as the renderer's `Text`. Paced advances the
+    /// release cursor a step-fraction each call (so the answer types out even on
+    /// a step the model text did not change); unpaced reveals the whole draft,
+    /// and only when new content arrived. `full` is the latest content draft, if
+    /// one was emitted this step.
+    fn reveal_content(
         &mut self,
-        committed_answer: &str,
-        draft_answer: &str,
+        out: &mut Vec<ChatEvent>,
+        full: Option<String>,
         ev: &StepProgressEvent<'_>,
-    ) -> (usize, String) {
-        if self.paced && !self.pace_off && committed_answer.contains("call:") {
-            self.pace_off = true;
-        }
-        if ev.block_done {
-            // The block's true length is now known; fold it into the EMA that
-            // sets how fast the next block releases this one's text.
-            self.est_block_steps = 0.5 * self.est_block_steps + 0.5 * ev.step_in_block as f32;
-        }
-        if !self.paced || self.pace_off {
-            self.released_content = committed_answer.len();
-            return (
-                common_prefix_len(committed_answer, draft_answer),
-                draft_answer.to_string(),
+    ) {
+        let committed = self.stream.content().to_string();
+        let (out_committed, out_text) = if self.paced && !self.clock.pace_off() {
+            self.released = self.clock.target(
+                true,
+                ev.block_done,
+                ev.step_in_block,
+                self.released,
+                &committed,
             );
-        }
-        // Paced. The cursor only ever trails the committed length: a block's own
-        // finishing step holds it (nothing new to pace against yet) and the
-        // following block's steps carry it forward.
-        self.released_content = self.released_content.min(committed_answer.len());
-        if !ev.block_done {
-            let frac = (ev.step_in_block as f32 / self.est_block_steps.max(1.0)).clamp(0.0, 1.0);
-            let remaining = committed_answer.len() - self.released_content;
-            self.released_content += (remaining as f32 * frac) as usize;
-        }
-        // Snap back to a char boundary so the slice never splits a code point.
-        while self.released_content < committed_answer.len()
-            && !committed_answer.is_char_boundary(self.released_content)
-        {
-            self.released_content -= 1;
-        }
-        (
-            self.released_content,
-            committed_answer[..self.released_content].to_string(),
-        )
-    }
-
-    /// Emit a `Text` (preceded by a `Rewind` when the new text revises rather
-    /// than extends what streamed), and remember it for the next diff.
-    fn emit_text(&mut self, out: &mut Vec<ChatEvent>, committed: usize, text: String) {
-        if text == self.last_text {
+            (self.released, committed[..self.released].to_string())
+        } else {
+            self.released = committed.len();
+            match full {
+                Some(full) => (common_prefix_len(&committed, &full), full),
+                None => return,
+            }
+        };
+        if out_text == self.last_text {
             return;
         }
-        if !text.starts_with(&self.last_text) {
+        if !out_text.starts_with(&self.last_text) {
             out.push(ChatEvent::Rewind {
-                common: common_prefix_len(&self.last_text, &text),
+                common: common_prefix_len(&self.last_text, &out_text),
             });
         }
         out.push(ChatEvent::Text {
-            committed,
-            text: text.clone(),
+            committed: out_committed,
+            text: out_text.clone(),
         });
-        self.last_text = text;
+        self.last_text = out_text;
     }
 
     pub fn on_step(&mut self, ev: &StepProgressEvent<'_>) -> Vec<ChatEvent> {
@@ -199,99 +164,58 @@ impl<D: TextDecoder> StreamDecoder<D> {
         if self.ended {
             return out;
         }
-
-        let sp = self.stab.on_step(ev);
-        if sp.new_block {
-            out.push(ChatEvent::BlockStart {
-                block: ev.block_idx,
-            });
-        }
-        out.push(ChatEvent::Status {
-            block: ev.block_idx,
-            step: ev.step_in_block,
-            max_steps: ev.max_steps,
-            accepted: ev.accept_count,
-            canvas: ev.argmax.len(),
-            locked: sp.ids.len(),
-        });
-
-        // Reasoning-separating path (`--show-thinking`, `/prethink`, or
-        // start-in-thought): re-split the whole generation each step so a thought
-        // spanning several blocks still classifies. Reasoning streams as
-        // `Thought` (when displayed), the answer after `<channel|>` as `Text`.
-        if self.thinking_display || self.start_in_thought {
-            if ev.block_done {
-                self.committed_ids.extend_from_slice(&sp.ids);
-                out.push(ChatEvent::BlockCommit {
-                    block: ev.block_idx,
-                    committed_tokens: sp.ids.len(),
-                });
-                if sp.hit_stop {
-                    self.ended = true;
+        let mut full_content = None;
+        for e in self.stream.on_step(ev) {
+            match e {
+                StreamEvent::Block { block } => out.push(ChatEvent::BlockStart { block }),
+                StreamEvent::Progress {
+                    block,
+                    step,
+                    max_steps,
+                    canvas,
+                    locked,
+                    accepted,
+                } => out.push(ChatEvent::Status {
+                    block,
+                    step,
+                    max_steps,
+                    accepted,
+                    canvas,
+                    locked,
+                }),
+                StreamEvent::Commit { block, tokens } => {
+                    out.push(ChatEvent::BlockCommit {
+                        block,
+                        committed_tokens: tokens,
+                    });
+                    self.clock
+                        .on_commit(ev.step_in_block, self.stream.content());
                 }
-            }
-            let seed = self.prethink_seed.as_deref().unwrap_or("");
-            let in_thought = self.start_in_thought;
-            let strip = crate::sample::strip_degenerate_token_ids;
-            // Committed view: finalized blocks only, whose answer is the
-            // immutable prefix. Full view: committed plus the live draft.
-            // Deriving `committed` from the committed view keeps it monotonic
-            // across blocks, so the renderer holds its print cursor mid-answer
-            // instead of re-emitting the whole reply on each block boundary.
-            let committed_split =
-                self.channels
-                    .split(&self.decoder, &strip(&self.committed_ids), in_thought);
-            let committed_answer = self.decoder.decode_content(&committed_split.content);
-            let full_split = if ev.block_done {
-                committed_split
-            } else {
-                let mut ids = self.committed_ids.clone();
-                ids.extend_from_slice(&sp.ids);
-                self.channels.split(&self.decoder, &strip(&ids), in_thought)
-            };
-            let thought = format!(
-                "{seed}{}",
-                self.decoder.decode_reasoning(&full_split.reasoning)
-            );
-            let answer = self.decoder.decode_content(&full_split.content);
-
-            if self.thinking_display && thought != self.last_thought {
-                out.push(ChatEvent::Thought {
-                    text: thought.clone(),
-                });
-                self.last_thought = thought;
-            }
-            let (committed, text) = self.paced_reveal(&committed_answer, &answer, ev);
-            self.emit_text(&mut out, committed, text);
-            return out;
-        }
-
-        if ev.block_done {
-            self.committed_ids.extend_from_slice(&sp.ids);
-            self.committed_text = self.decoder.decode_content(&self.committed_ids);
-            out.push(ChatEvent::BlockCommit {
-                block: ev.block_idx,
-                committed_tokens: sp.ids.len(),
-            });
-            if sp.hit_stop {
-                self.ended = true;
+                StreamEvent::Text {
+                    channel: Channel::Reasoning,
+                    text,
+                    ..
+                } => {
+                    if self.thinking_display {
+                        let thought =
+                            format!("{}{}", self.prethink_seed.as_deref().unwrap_or(""), text);
+                        if thought != self.last_thought {
+                            out.push(ChatEvent::Thought {
+                                text: thought.clone(),
+                            });
+                            self.last_thought = thought;
+                        }
+                    }
+                }
+                StreamEvent::Text {
+                    channel: Channel::Content,
+                    text,
+                    ..
+                } => full_content = Some(text),
+                StreamEvent::End { .. } => self.ended = true,
             }
         }
-
-        // Full visible text: the committed answer plus this block's speculative
-        // draft. Cloned up front so the paced-reveal borrow does not collide with
-        // the committed field.
-        let committed_answer = self.committed_text.clone();
-        let mut draft = committed_answer.clone();
-        if !ev.block_done {
-            let suffix = crate::sample::strip_degenerate_token_ids(&sp.ids);
-            if !suffix.is_empty() {
-                self.decoder.decode_append(&mut draft, &suffix);
-                draft = crate::chat_template::sanitize_model_reply(&draft);
-            }
-        }
-        let (committed, text) = self.paced_reveal(&committed_answer, &draft, ev);
-        self.emit_text(&mut out, committed, text);
+        self.reveal_content(&mut out, full_content, ev);
         out
     }
 }

--- a/src/decoder/tests.rs
+++ b/src/decoder/tests.rs
@@ -419,6 +419,42 @@ fn ids(s: &str) -> Vec<u32> {
     s.chars().map(|c| c as u32).collect()
 }
 
+/// The last content `Text` in an event list, as `(committed, text)`.
+fn content(events: &[StreamEvent]) -> Option<(usize, String)> {
+    events.iter().rev().find_map(|e| match e {
+        StreamEvent::Text {
+            channel: Channel::Content,
+            committed,
+            text,
+        } => Some((*committed, text.clone())),
+        _ => None,
+    })
+}
+
+#[test]
+fn stream_finalized_prefix_never_changes() {
+    let mut s = DiffusionStream::new(
+        FakeDecoder,
+        StreamConfig {
+            stops: vec![],
+            ..Default::default()
+        },
+    );
+    // Block 1 commits "Ab": the whole two bytes are finalized.
+    assert_eq!(
+        content(&s.on_step(&step(1, 1, &ids("Ab"), true))),
+        Some((2, "Ab".into()))
+    );
+    // Block 2's draft grows the text, but `text[..committed]` stays "Ab" and the
+    // watermark only advances.
+    s.on_step(&step(2, 1, &ids("cd"), false));
+    s.on_step(&step(2, 2, &ids("cd"), false));
+    let (committed, text) = content(&s.on_step(&step(2, 3, &ids("cd"), false))).unwrap();
+    assert_eq!(&text[..2], "Ab");
+    assert!(committed >= 2);
+    assert_eq!(text, "Abcd");
+}
+
 #[test]
 fn unpaced_reveals_a_committed_block_whole() {
     // The default (pacing off) surfaces a finished block's answer at once.

--- a/src/metal/step_generate/turn.rs
+++ b/src/metal/step_generate/turn.rs
@@ -900,21 +900,7 @@ pub fn propose_block(
                 last_denoise_stop,
             );
         }
-        // Accepted: notify streamers that this block's active argmax is final.
-        // A prefix-exited block's final draft is only the settled head — the
-        // churning tail rows must never stream as final text.
-        if let Some(ref observer) = cfg.step_observer {
-            observer(&StepProgressEvent {
-                block_idx,
-                max_blocks,
-                step_in_block: block_step_count,
-                max_steps,
-                argmax: &st.prev_argmax[..prefix_exit_head.unwrap_or(active).min(active)],
-                accept_count: accept_hist.last().copied().unwrap_or(0),
-                mean_entropy: st.mean_entropy,
-                block_done: true,
-            });
-        }
+        // block_done fires after the confidence trim below, with the committed tokens.
         break 'attempt (
             st,
             block_step_count,
@@ -1116,6 +1102,23 @@ pub fn propose_block(
             argmax_tokens.truncate(first_bad);
             conf_trim_row = Some(first_bad);
         }
+    }
+
+    // Accepted: notify streamers that this block is final, with the committed
+    // tokens (post prefix-exit and confidence trim), so a streamer's finalized
+    // text stays a prefix of the turn's reply. The trimmed tail re-denoises into
+    // the next block.
+    if let Some(ref observer) = cfg.step_observer {
+        observer(&StepProgressEvent {
+            block_idx,
+            max_blocks,
+            step_in_block: block_step_count,
+            max_steps,
+            argmax: &argmax_tokens,
+            accept_count: accept_hist.last().copied().unwrap_or(0),
+            mean_entropy: st.mean_entropy,
+            block_done: true,
+        });
     }
 
     if progress_enabled() {


### PR DESCRIPTION
## What

Chat's `StreamDecoder` and serve's `DiffusionStreamMapper` each re-derived the stabilize / channel-split / committed-tracking rules — and, since the typewriter work, a second copy of the paced release. This unifies them.

- **`decoder/core.rs` — one canonical `DiffusionStream`.** Owns the `Stabilizer` + `ChannelIds::split` + committed tracking, and emits neutral `StreamEvent`s: `Block`, `Progress`, `Text{channel, committed, text}`, `Commit`, `End`. `text[..committed]` is the model-locked prefix (never taken back); `text[committed..]` is the draft.
- **`decoder/pace.rs` — shared `PaceClock`.** The paced-release curve (EMA + step-fraction + tool-call gate), applied by a consumer as a display policy. One clock per decoder, one release cursor per channel.
- **`serve.rs` and `stream.rs` are now thin adapters.** serve turns `Text` into `Draft` + paced `Content`/`Reasoning` appends; chat into `Status`/`Text`/`Thought`/`Rewind`, pacing the content reveal so it types out. The two lost ~100 lines of duplicated logic.

## Also: a finalize divergence fix (`step_generate/turn.rs`)

The `block_done` observer fired with the **pre-trim** argmax, but `out.token_ids` gets the tokens **after** the confidence-trim (which drops the low-confidence duplication tail — `the the`, `golden golden`). So a streamer finalized a tail the reply then dropped, and the renderer printed a "the streamed reply above was revised" correction. The notification now fires after the trim with the committed `argmax_tokens` — the same value `commit_block` appends — so a streamer's finalized text is a prefix of the turn's reply by construction.

## Safety

- `golden` **8/8 byte-identical** and `smoketest` **17/17** — display-only; the reply is untouched.
- serve wire unit tests **14/14 byte-identical**, server integration **12/12**.
- decoder tests **35/35** (chat + serve + a new core watermark-contract test), chat tests **18/18**, clippy/fmt clean.

The finalize-divergence fix is verified by construction (observer and commit now pass the identical `argmax_tokens`) plus golden; the confidence-trim is rare on demand, so a live before/after wasn't reproducible cheaply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
