### PR TITLE
Link-time registration for shader includes and the kernel manifest

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -146,7 +146,8 @@ knows `.metal` paths; `src/metal/` (the runtime) consumes pipelines via
 - FC 1–3 are global (shape-assert, dump, quant-format); local axes are
   registered in each kernel's `SPEC` (see `diffgemma manifest`).
 - Quoted `#include "x.metal"` resolves from `src/shaders/include/` at
-  runtime (table in `common/expand.rs`, mechanism in `crates/gpukit`); the
+  runtime (folder registered whole in `common/expand.rs` via
+  `gpukit::register_includes!`; adding a header is adding the file); the
   pipeline binary archive keys on the whole-tree hash, so shader edits can
   never be served stale — but if golden regresses right after a `.metal`
   edit, **rebuild clean before diagnosing** (a mid-sequence binary can
@@ -235,7 +236,8 @@ never two model-loading PROCESSES at once.
   attention scale, V aliased from raw k_proj on full layers). These are
   checkpoint-specific and several are counterintuitive — do not "correct"
   them from general Gemma knowledge without checking the reference.
-- **Kernel FC registration:** each kernel's `SPEC` const;
+- **Kernel FC registration:** each kernel's `SPEC` const, scattered into
+  the gathered manifest map beside its declaration (no central list);
   `diffgemma manifest` renders the full TOML view.
 - **Env flags:** `src/flags/` (mod.rs = registry + parse, accessors.rs =
   read surface) is the single registry — check it before inventing any

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -541,10 +541,11 @@ are local-only dev tooling for experiment arms (`quantize --overlay`,
 ## Runtime shape
 
 - `crates/gpukit` — GPU mechanism with no model or policy knowledge:
-  device/queue context, `#include` expansion, function-constant
-  specialization with cache labels derived from the full input set (FC
-  values + source hash), the pipeline binary-archive cache (keyed on the
-  whole shader-tree hash), buffer pool, one-shot dispatch helpers.
+  device/queue context, `#include` expansion over link-time-registered
+  header folders (`register_includes!`), function-constant specialization
+  with cache labels derived from the full input set (FC values + source
+  hash), the pipeline binary-archive cache (keyed on the whole shader-tree
+  hash), buffer pool, one-shot dispatch helpers.
 - `src/shaders/<group>/<kernel>/` — every kernel's Rust wrapper, Metal
   source, CPU oracle, and manifest `SPEC` colocated (see AGENTS.md §4).
 - `src/metal/` — the runtime: the gpukit policy layer (`device.rs`: flag

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytemuck"
+version = "1.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,6 +73,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "1.0.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "914a755b7c2d4af2bdcff7ce1739e2db9a1b81a9b07123d8015786ae03c0980d"
+dependencies = [
+ "link-section",
+ "linktime-proc-macro",
+]
+
+[[package]]
 name = "diffgemma"
 version = "0.1.0"
 dependencies = [
@@ -76,6 +92,7 @@ dependencies = [
  "objc2-foundation",
  "objc2-metal",
  "rustyline",
+ "scattered-collect",
  "serde",
  "serde_json",
  "sha2",
@@ -91,6 +108,12 @@ dependencies = [
  "block-buffer",
  "crypto-common",
 ]
+
+[[package]]
+name = "dtor"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3f6c362b2bbd7063090886afd78978f5dbf1f11da7efcc40f81d32c943fac1"
 
 [[package]]
 name = "endian-type"
@@ -118,9 +141,11 @@ dependencies = [
 name = "gpukit"
 version = "0.1.0"
 dependencies = [
+ "include_dir",
  "objc2",
  "objc2-foundation",
  "objc2-metal",
+ "scattered-collect",
 ]
 
 [[package]]
@@ -130,6 +155,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
  "windows-sys",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]
@@ -143,6 +187,32 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "link-section"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39c29a617ce3df32c08497bdc1ab6e2376e0b17948ac166a2fbe5977c5954cd9"
+dependencies = [
+ "linktime-proc-macro",
+]
+
+[[package]]
+name = "linktime"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e69a9e2780a5e20ee9ef734fa17fa97ad02dd66face418654ede43ff0ade4c09"
+dependencies = [
+ "ctor",
+ "dtor",
+ "link-section",
+]
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e57c38c1e860fd37c604281cdfb1dd2216977fd76a50f85ba2f388ef3219616"
 
 [[package]]
 name = "log"
@@ -273,6 +343,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "safe_arch"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42c6efa15875e6ecb39ca61fb0b0c1a40b84fac5a5ffe71eef7d1000c8eb3f5f"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "scattered-collect"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fefb57ade8e9c6229a2fcfc6bb91310d3b448cd6d3a9caabfbcaa9ce630ef267"
+dependencies = [
+ "ctor",
+ "link-section",
+ "linktime",
+ "linktime-proc-macro",
+ "wide",
+ "xxhash-rust",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -386,6 +479,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
+name = "wide"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de2aaf408e58689c2096682331b1f42bb2d9f2ed6b11560407d023cd0a6c634e"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -399,6 +502,12 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "xxhash-rust"
+version = "0.8.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aee1b19627c7c60102ab80d3a9cbe18de90bfe03bfa6c3715447681f0e8c8af6"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,9 @@ shell-download = "0.22"
 # Integrity pin for external HF-safetensors refs in layered packs (hash of the
 # safetensors header only, not the multi-GiB payload — see dgq/hf_resolve.rs).
 sha2 = "0.10"
+# Link-time kernel registry: each kernel's SPEC scatters into the gathered
+# manifest (src/shaders/common/manifest.rs).
+scattered-collect = "0.22"
 
 # Host-side test code runs real inference (smokes, KV fingerprints over
 # hundreds of MB); at opt-level 0 the per-byte loops dominate suite wall.

--- a/crates/gpukit/Cargo.toml
+++ b/crates/gpukit/Cargo.toml
@@ -5,6 +5,10 @@ edition = "2024"
 description = "GPU compute infrastructure: pipeline compilation, specialization, caching, buffers"
 license = "MIT"
 
+[dependencies]
+scattered-collect = "0.22"
+include_dir = "0.7"
+
 [target.'cfg(target_os = "macos")'.dependencies]
 objc2 = { version = "0.6", default-features = false, features = ["std"] }
 objc2-metal = { version = "0.3", default-features = false, features = [

--- a/crates/gpukit/src/includes.rs
+++ b/crates/gpukit/src/includes.rs
@@ -1,0 +1,77 @@
+//! Link-time registry of shader include folders.
+//!
+//! Each crate that owns shared headers registers its folder once with
+//! [`register_includes!`]; [`include_table`] collects every registered folder
+//! into one name → contents table, which the Metal context uses to resolve
+//! `#include "name.metal"`. Registration is the only step — a header on disk
+//! in a registered folder cannot be forgotten.
+
+use crate::Error;
+
+pub use include_dir;
+pub use include_dir::Dir;
+pub use scattered_collect;
+pub use scattered_collect::declarative::{gather, scatter};
+
+/// One registered folder of shader headers.
+pub struct IncludeFolder(pub &'static Dir<'static>);
+
+gather! {
+    #[gather]
+    pub static INCLUDE_DIRS: scattered_collect::ScatteredSlice<IncludeFolder>;
+}
+
+/// Embed a folder of shader headers and register it for `#include`
+/// resolution in every [`crate::metal::Context`].
+///
+/// `path` is an `include_dir!` path, e.g.
+/// `"$CARGO_MANIFEST_DIR/src/shaders/include"`. Invoke at most once per
+/// module. The registering crate's build script must emit
+/// `rerun-if-changed` for the folder — cargo does not track embedded files
+/// on its own.
+#[macro_export]
+macro_rules! register_includes {
+    ($path:tt) => {
+        const _: () = {
+            // `include_dir!` emits paths naming its own crate; this alias
+            // resolves them without the caller depending on it directly.
+            use $crate::includes::include_dir;
+            static DIR: include_dir::Dir<'static> = include_dir::include_dir!($path);
+            $crate::includes::scatter! {
+                #[scatter($crate::includes::INCLUDE_DIRS)]
+                static REG: $crate::includes::IncludeFolder =
+                    $crate::includes::IncludeFolder(&DIR);
+            }
+        };
+    };
+}
+
+/// The union of every registered folder as a name → contents table.
+///
+/// Folders are read non-recursively. Fails on a header that is not UTF-8 or
+/// a name registered by two folders — bare-name `#include` resolution has no
+/// way to pick between duplicates.
+pub fn include_table() -> Result<Vec<(&'static str, &'static str)>, Error> {
+    let mut table: Vec<(&'static str, &'static str)> = Vec::new();
+    for folder in INCLUDE_DIRS.iter() {
+        for file in folder.0.files() {
+            let path = file.path();
+            let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                continue;
+            };
+            let Some(contents) = file.contents_utf8() else {
+                return Err(Error::Compile(format!(
+                    "registered include {name:?} is not UTF-8"
+                )));
+            };
+            if table.iter().any(|(n, _)| *n == name) {
+                return Err(Error::Compile(format!(
+                    "include {name:?} is registered by two folders; bare-name \
+                     #include resolution cannot pick one"
+                )));
+            }
+            table.push((name, contents));
+        }
+    }
+    Ok(table)
+}

--- a/crates/gpukit/src/lib.rs
+++ b/crates/gpukit/src/lib.rs
@@ -5,10 +5,13 @@
 //!
 //! The crate holds mechanism only. Anything policy-shaped — which axes a
 //! kernel specializes on, cache configuration, flag parsing — belongs to the
-//! caller and arrives through [`metal::ContextConfig`] and plain arguments.
+//! caller and arrives through [`metal::CacheConfig`], [`register_includes!`],
+//! and plain arguments.
 
 mod error;
 pub use error::Error;
+
+pub mod includes;
 
 #[cfg(target_os = "macos")]
 pub mod metal;

--- a/crates/gpukit/src/metal/context.rs
+++ b/crates/gpukit/src/metal/context.rs
@@ -10,16 +10,6 @@ use objc2_metal::{
 };
 use std::sync::Arc;
 
-/// Everything a [`Context`] needs from the application: the shared-header
-/// table for `#include` expansion and the pipeline-cache settings.
-#[derive(Clone)]
-pub struct ContextConfig {
-    /// Shared shader headers by include name, resolved during
-    /// [`Context::compile_library`]. An unknown `#include "name"` panics.
-    pub includes: &'static [(&'static str, &'static str)],
-    pub cache: CacheConfig,
-}
-
 /// Stable (no-random-seed) hash of a shader source for cache-label derivation.
 pub fn source_hash(source: &str) -> u64 {
     // FNV-1a: deterministic across runs (std DefaultHasher is randomized).
@@ -111,24 +101,26 @@ impl FcValues {
 pub struct Context {
     pub device: Retained<ProtocolObject<dyn MTLDevice>>,
     pub queue: Retained<ProtocolObject<dyn MTLCommandQueue>>,
-    config: ContextConfig,
+    includes: Vec<(&'static str, &'static str)>,
     cache: Arc<PipelineArchiveCache>,
 }
 
 impl Context {
-    /// Open the system default device. The first context in the process fixes
-    /// the pipeline cache's settings; later contexts share that cache and
-    /// their `cache` config is ignored.
-    pub fn new(config: ContextConfig) -> Result<Self, Error> {
+    /// Open the system default device. Shared headers come from the folders
+    /// registered with [`crate::register_includes!`]. The first context in
+    /// the process fixes the pipeline cache's settings; later contexts share
+    /// that cache and their `cache` config is ignored.
+    pub fn new(cache: CacheConfig) -> Result<Self, Error> {
+        let includes = crate::includes::include_table()?;
         let device = MTLCreateSystemDefaultDevice().ok_or(Error::Gpu("no Metal device"))?;
         let queue = device
             .newCommandQueue()
             .ok_or(Error::Gpu("failed to create Metal command queue"))?;
-        let cache = PipelineArchiveCache::shared(&device, &config.cache)?;
+        let cache = PipelineArchiveCache::shared(&device, &cache)?;
         Ok(Self {
             device,
             queue,
-            config,
+            includes,
             cache,
         })
     }
@@ -138,7 +130,7 @@ impl Context {
         &self,
         source: &str,
     ) -> Result<Retained<ProtocolObject<dyn MTLLibrary>>, Error> {
-        let ns_source = NSString::from_str(&expand(source, self.config.includes));
+        let ns_source = NSString::from_str(&expand(source, &self.includes));
         self.device
             .newLibraryWithSource_options_error(&ns_source, None)
             .map_err(compile_error)
@@ -236,16 +228,13 @@ kernel void pc_k2(device float* o [[buffer(0)]], uint i [[thread_position_in_gri
 kernel void pc_k3(device float* o [[buffer(0)]], uint i [[thread_position_in_grid]]) { o[i] = 3.0f; }
 ";
 
-    fn test_config() -> ContextConfig {
-        ContextConfig {
-            includes: &[],
-            cache: CacheConfig {
-                enabled: true,
-                dir: Some(std::env::temp_dir().join("gpukit-test-pipeline-cache")),
-                namespace: "gpukit-test",
-                key: 0x67706b74,
-                verbose: false,
-            },
+    fn test_config() -> CacheConfig {
+        CacheConfig {
+            enabled: true,
+            dir: Some(std::env::temp_dir().join("gpukit-test-pipeline-cache")),
+            namespace: "gpukit-test",
+            key: 0x67706b74,
+            verbose: false,
         }
     }
 

--- a/crates/gpukit/src/metal/mod.rs
+++ b/crates/gpukit/src/metal/mod.rs
@@ -7,7 +7,7 @@ mod expand;
 mod pipeline_cache;
 
 pub use buffer::BufferPool;
-pub use context::{ComputePipeline, Context, ContextConfig, FcValues, source_hash};
+pub use context::{ComputePipeline, Context, FcValues, source_hash};
 pub use dispatch::{
     dispatch_1d, dispatch_1d_ranged, dispatch_grid, dispatch_rows, div_up, set_bytes,
 };

--- a/src/metal/device.rs
+++ b/src/metal/device.rs
@@ -111,10 +111,7 @@ impl std::ops::Deref for MetalContext {
 
 impl MetalContext {
     pub fn new() -> Result<Self, Error> {
-        let inner = gk::Context::new(gk::ContextConfig {
-            includes: crate::shaders::expand::INCLUDES,
-            cache: cache_config(),
-        })?;
+        let inner = gk::Context::new(cache_config())?;
         // Record the working-set cap so the q8-KV auto policy (flags::kv_q8)
         // can scale to this device's RAM.
         crate::flags::set_gpu_working_set_cap(inner.device.recommendedMaxWorkingSetSize());

--- a/src/shaders/attn/attention/mod.rs
+++ b/src/shaders/attn/attention/mod.rs
@@ -831,13 +831,13 @@ pub fn bench_path(f: &Fixture, iters: usize, path: u8) -> Result<f64, Error> {
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "attention",
         entry: "attention",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/attn/attention/mod.rs
+++ b/src/shaders/attn/attention/mod.rs
@@ -1038,6 +1038,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/attn/attention/mod.rs
+++ b/src/shaders/attn/attention/mod.rs
@@ -1037,3 +1037,7 @@ mod tests {
         );
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/attn/attention/mod.rs
+++ b/src/shaders/attn/attention/mod.rs
@@ -830,14 +830,15 @@ pub fn bench_path(f: &Fixture, iters: usize, path: u8) -> Result<f64, Error> {
     Ok(best)
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "attention",
-    entry: "attention",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "attention",
+        entry: "attention",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -1037,5 +1038,3 @@ mod tests {
         );
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/attn/attention_gemm/mod.rs
+++ b/src/shaders/attn/attention_gemm/mod.rs
@@ -694,13 +694,13 @@ pub fn bench_tuned(
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "attention_gemm",
         entry: "attn_gemm_qk",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/attn/attention_gemm/mod.rs
+++ b/src/shaders/attn/attention_gemm/mod.rs
@@ -693,14 +693,15 @@ pub fn bench_tuned(
     })
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "attention_gemm",
-    entry: "attn_gemm_qk",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "attention_gemm",
+        entry: "attn_gemm_qk",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -791,5 +792,3 @@ mod tests {
         }
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/attn/attention_gemm/mod.rs
+++ b/src/shaders/attn/attention_gemm/mod.rs
@@ -792,6 +792,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/attn/attention_gemm/mod.rs
+++ b/src/shaders/attn/attention_gemm/mod.rs
@@ -791,3 +791,7 @@ mod tests {
         }
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/attn/attention_topk/mod.rs
+++ b/src/shaders/attn/attention_topk/mod.rs
@@ -602,3 +602,7 @@ mod tests {
         }
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/attn/attention_topk/mod.rs
+++ b/src/shaders/attn/attention_topk/mod.rs
@@ -432,14 +432,15 @@ pub fn bench_stages(
     Ok((qk, sm, pv))
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "attention_topk",
-    entry: "attn_topk_softmax",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "attention_topk",
+        entry: "attn_topk_softmax",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -602,5 +603,3 @@ mod tests {
         }
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/attn/attention_topk/mod.rs
+++ b/src/shaders/attn/attention_topk/mod.rs
@@ -433,13 +433,13 @@ pub fn bench_stages(
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "attention_topk",
         entry: "attn_topk_softmax",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/attn/attention_topk/mod.rs
+++ b/src/shaders/attn/attention_topk/mod.rs
@@ -603,6 +603,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/attn/qk_rope_kv/mod.rs
+++ b/src/shaders/attn/qk_rope_kv/mod.rs
@@ -489,6 +489,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/attn/qk_rope_kv/mod.rs
+++ b/src/shaders/attn/qk_rope_kv/mod.rs
@@ -428,13 +428,13 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "qk_rope_kv",
         entry: "qk_rope_kv",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/attn/qk_rope_kv/mod.rs
+++ b/src/shaders/attn/qk_rope_kv/mod.rs
@@ -427,14 +427,15 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
     Ok(pack_out(&q, &k, &kvcache, f))
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "qk_rope_kv",
-    entry: "qk_rope_kv",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "qk_rope_kv",
+        entry: "qk_rope_kv",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -488,5 +489,3 @@ mod tests {
         min_cos = 0.999,
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/attn/qk_rope_kv/mod.rs
+++ b/src/shaders/attn/qk_rope_kv/mod.rs
@@ -488,3 +488,7 @@ mod tests {
         min_cos = 0.999,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/common/expand.rs
+++ b/src/shaders/common/expand.rs
@@ -1,110 +1,18 @@
-//! Diffgemma's shared-header table for gpukit's `#include` expansion.
+//! Registers `src/shaders/include/` for gpukit's `#include` expansion.
 //!
-//! Kernels embed their Metal source with a file-relative `include_str!` (the
-//! .metal sits next to its mod.rs); every shared header under
-//! `src/shaders/include/` gets a row here. Adding a header = add the file AND
-//! a row (the `include_table_matches_dir` test enforces both directions).
+//! Every shared header in that folder is embedded and resolvable by name —
+//! adding a header is adding the file. build.rs emits `rerun-if-changed`
+//! for the shader tree, which covers the embedded folder.
 
-/// Every shared header under `src/shaders/include/`, by include name.
-pub static INCLUDES: &[(&str, &str)] = &[
-    (
-        "activations.metal",
-        include_str!("../include/activations.metal"),
-    ),
-    ("arena.metal", include_str!("../include/arena.metal")),
-    ("arena_fc.metal", include_str!("../include/arena_fc.metal")),
-    (
-        "attention_device.metal",
-        include_str!("../include/attention_device.metal"),
-    ),
-    ("common.metal", include_str!("../include/common.metal")),
-    (
-        "debug_status.metal",
-        include_str!("../include/debug_status.metal"),
-    ),
-    ("dequant.metal", include_str!("../include/dequant.metal")),
-    (
-        "dgq_kernels.metal",
-        include_str!("../include/dgq_kernels.metal"),
-    ),
-    ("fc_axes.metal", include_str!("../include/fc_axes.metal")),
-    (
-        "gemm_block_tile.metal",
-        include_str!("../include/gemm_block_tile.metal"),
-    ),
-    ("gemm_fc.metal", include_str!("../include/gemm_fc.metal")),
-    (
-        "gemm_frag_tile.metal",
-        include_str!("../include/gemm_frag_tile.metal"),
-    ),
-    (
-        "gemm_stacked.metal",
-        include_str!("../include/gemm_stacked.metal"),
-    ),
-    (
-        "gemm_stacked_fc.metal",
-        include_str!("../include/gemm_stacked_fc.metal"),
-    ),
-    (
-        "gqa_device.metal",
-        include_str!("../include/gqa_device.metal"),
-    ),
-    (
-        "moe_grouped_device.metal",
-        include_str!("../include/moe_grouped_device.metal"),
-    ),
-    (
-        "moe_grouped_dispatch.metal",
-        include_str!("../include/moe_grouped_dispatch.metal"),
-    ),
-    (
-        "moe_router_device.metal",
-        include_str!("../include/moe_router_device.metal"),
-    ),
-    (
-        "qgemm_grouped.metal",
-        include_str!("../include/qgemm_grouped.metal"),
-    ),
-    (
-        "sampler_device.metal",
-        include_str!("../include/sampler_device.metal"),
-    ),
-    (
-        "sc_prob_scale.metal",
-        include_str!("../include/sc_prob_scale.metal"),
-    ),
-];
+gpukit::register_includes!("$CARGO_MANIFEST_DIR/src/shaders/include");
 
 #[cfg(test)]
 mod tests {
-    use super::*;
-
     #[test]
-    fn include_table_matches_dir() {
-        let dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("src/shaders/include");
-        let mut on_disk: Vec<String> = std::fs::read_dir(&dir)
-            .expect("read include dir")
-            .map(|e| {
-                e.expect("dir entry")
-                    .file_name()
-                    .to_string_lossy()
-                    .into_owned()
-            })
-            .filter(|n| n.ends_with(".metal"))
-            .collect();
-        on_disk.sort();
-        let mut in_table: Vec<String> = INCLUDES.iter().map(|(n, _)| n.to_string()).collect();
-        in_table.sort();
-        assert_eq!(
-            on_disk, in_table,
-            "src/shaders/include/ and expand::INCLUDES must list the same headers"
-        );
-    }
-
-    #[cfg(target_os = "macos")]
-    #[test]
-    fn expand_resolves_every_production_include() {
-        let s = gpukit::metal::expand(crate::shaders::moe_grouped::SHADER, INCLUDES);
+    fn every_production_include_resolves() {
+        let table = gpukit::includes::include_table().expect("include table");
+        assert!(!table.is_empty(), "no include folders registered");
+        let s = gpukit::metal::expand(crate::shaders::moe_grouped::SHADER, &table);
         assert!(s.contains("kernel void moe_grouped"));
         assert!(s.len() > 8000);
     }

--- a/src/shaders/common/manifest.rs
+++ b/src/shaders/common/manifest.rs
@@ -23,19 +23,32 @@ use scattered_collect::{ScatteredMap, gather};
 pub static MANIFEST: ScatteredMap<&'static str, &'static KernelSpec>;
 
 /// Declare a `KernelSpec` const and scatter it into [`MANIFEST`], keyed by
-/// its entry name. Wraps the declaration verbatim, so a spec cannot exist
-/// without being registered:
+/// its entry name — a spec cannot exist without being registered. The macro
+/// supplies the type and brings this module's names plus `QuantFormat` /
+/// `ElemDtype` into scope for the field values:
 ///
 /// ```ignore
 /// crate::kernel_spec! {
-///     pub const SPEC: crate::shaders::manifest::KernelSpec = ...;
+///     pub const SPEC {
+///         name: "gelu",
+///         entry: "gelu",
+///         quant_formats: &[QuantFormat::Q4Affine],
+///         fc: &[],
+///         variants: KernelVariants::Gelu,
+///     }
 /// }
 /// ```
 #[macro_export]
 macro_rules! kernel_spec {
-    ($(#[$meta:meta])* $vis:vis const $name:ident: $ty:ty = $spec:expr;) => {
+    ($(#[$meta:meta])* $vis:vis const $name:ident { $($fields:tt)* }) => {
         $(#[$meta])*
-        $vis const $name: $ty = $spec;
+        $vis const $name: $crate::shaders::common::manifest::KernelSpec = {
+            #[allow(unused_imports)]
+            use $crate::shaders::common::manifest::*;
+            #[allow(unused_imports)]
+            use $crate::shaders::common::variant::{ElemDtype, QuantFormat};
+            KernelSpec { $($fields)* }
+        };
         // The const block scopes the static, so one module can declare
         // several specs without inventing unique names.
         const _: () = {

--- a/src/shaders/common/manifest.rs
+++ b/src/shaders/common/manifest.rs
@@ -22,6 +22,25 @@ use scattered_collect::{ScatteredMap, gather};
 #[gather]
 pub static MANIFEST: ScatteredMap<&'static str, &'static KernelSpec>;
 
+/// Scatter one or more `SPEC` consts into [`MANIFEST`], keyed by entry name.
+/// Invoke beside the declarations: `crate::register_kernel_specs!(SPEC);`
+#[macro_export]
+macro_rules! register_kernel_specs {
+    ($($spec:ident),+ $(,)?) => {
+        $(
+            // The const block scopes the static, so one module can register
+            // several specs without inventing unique names.
+            const _: () = {
+                #[::scattered_collect::scatter($crate::shaders::common::manifest::MANIFEST)]
+                static REG: (
+                    &'static str,
+                    &'static $crate::shaders::common::manifest::KernelSpec,
+                ) = ($spec.entry, &$spec);
+            };
+        )+
+    };
+}
+
 pub struct KernelSpec {
     pub name: &'static str,
     pub entry: &'static str,

--- a/src/shaders/common/manifest.rs
+++ b/src/shaders/common/manifest.rs
@@ -1,9 +1,11 @@
 //! Kernel FC axis manifest — validity contract for pipeline specialization.
 //!
 //! Each registered kernel declares its own `SPEC` const in its kernel
-//! directory (colocated with the Metal source); `MANIFEST` below collects
-//! them. This module is the enforcement layer: invalid tuples cannot be
-//! compiled, and tier-1 tests enumerate every valid variant row.
+//! directory (colocated with the Metal source) and scatters it into the
+//! gathered `MANIFEST` map beside the declaration — there is no central
+//! list to keep in sync. This module is the enforcement layer: invalid
+//! tuples cannot be compiled, and tier-1 tests enumerate every valid
+//! variant row.
 //!
 //! The human-readable TOML form is GENERATED from these specs at runtime
 //! (`render_toml()`, `diffgemma manifest`) — there is no checked-in
@@ -15,11 +17,10 @@
 
 use super::variant::{ElemDtype, FcBool, FcUInt, KernelVariant, QuantFormat};
 use crate::Error;
+use scattered_collect::{ScatteredMap, gather};
 
-/// Collected kernel specs (each lives beside its kernel).
-pub struct Manifest {
-    pub kernels: &'static [&'static KernelSpec],
-}
+#[gather]
+pub static MANIFEST: ScatteredMap<&'static str, &'static KernelSpec>;
 
 pub struct KernelSpec {
     pub name: &'static str,
@@ -65,41 +66,15 @@ pub struct SwigluSplitVariant {
     pub in_place: bool,
 }
 
-pub static MANIFEST: Manifest = Manifest {
-    kernels: &[
-        &crate::shaders::rms_norm_rows::SPEC,
-        &crate::shaders::rms_norm_rows_tiled::SPEC,
-        &crate::shaders::swiglu::SPEC,
-        &crate::shaders::swiglu::SPEC_MOE_GATE_UP,
-        &crate::shaders::gelu::SPEC,
-        &crate::shaders::embed_gather::SPEC,
-        &crate::shaders::logit_rowstats::SPEC,
-        &crate::shaders::sc_prob_cols::SPEC,
-        &crate::shaders::sample_rowstats::SPEC,
-        &crate::shaders::sample_commit::SPEC,
-        &crate::shaders::sample_apply::SPEC,
-        &crate::shaders::sample_write::SPEC,
-        &crate::shaders::qk_rope_kv::SPEC,
-        &crate::shaders::attention::SPEC,
-        &crate::shaders::attention_gemm::SPEC,
-        &crate::shaders::attention_topk::SPEC,
-        &crate::shaders::moe_router::SPEC,
-        &crate::shaders::moe_bucket_count::SPEC,
-        &crate::shaders::moe_bucket_fill::SPEC,
-        &crate::shaders::moe_grouped::SPEC,
-        &crate::shaders::moe_scatter_weighted::SPEC,
-        &crate::shaders::gemm_linear_grouped::SPEC,
-        &crate::shaders::gemm_block_grouped::SPEC,
-        &crate::shaders::gemm_linear_f32::SPEC,
-        &crate::shaders::gemm_q8_linear_f32::SPEC,
-        &crate::shaders::oracle::gemm::gemm_block::SPEC,
-        &crate::shaders::gemm_block_stacked::SPEC,
-        &crate::shaders::gemm_rowk::SPEC,
-    ],
-};
-
 pub fn spec_by_entry(entry: &str) -> Option<&'static KernelSpec> {
-    MANIFEST.kernels.iter().copied().find(|k| k.entry == entry)
+    MANIFEST.get(entry).copied()
+}
+
+/// Every registered spec, sorted by name for deterministic output.
+pub fn specs() -> Vec<&'static KernelSpec> {
+    let mut kernels: Vec<&'static KernelSpec> = MANIFEST.values().copied().collect();
+    kernels.sort_by_key(|k| k.name);
+    kernels
 }
 
 /// Render the collected specs as the human-readable TOML manifest.
@@ -114,7 +89,7 @@ pub fn render_toml() -> String {
          # Pipeline construction in Rust MUST only build tuples listed under [[kernel.variants]].\n\
          # Tier-1 tests MUST cover every [[kernel.variants]] row (see manifest.rs tests).\n",
     );
-    for k in MANIFEST.kernels {
+    for k in specs() {
         out.push_str(&format!(
             "\n[[kernel]]\nname = \"{}\"\nentry = \"{}\"\n",
             k.name, k.entry
@@ -326,14 +301,14 @@ mod tests {
     #[test]
     fn manifest_entries_unique() {
         let mut names = std::collections::HashSet::new();
-        for k in MANIFEST.kernels {
+        for k in specs() {
             assert!(names.insert(k.entry), "duplicate entry {}", k.entry);
         }
     }
 
     #[test]
     fn all_fc_maps_collision_free() {
-        for k in MANIFEST.kernels {
+        for k in specs() {
             let indices: Vec<u32> = k.fc.iter().map(|(idx, _)| *idx).collect();
             assert_no_fc_collisions(k.entry, &indices).unwrap();
         }
@@ -341,7 +316,7 @@ mod tests {
 
     #[test]
     fn all_manifest_variants_enumerated() {
-        for k in MANIFEST.kernels {
+        for k in specs() {
             match k.variants {
                 KernelVariants::RmsNormRows { rows } => assert_eq!(rows.len(), 2),
                 KernelVariants::RmsNormRowsTiled { rows } => assert_eq!(rows.len(), 2),
@@ -360,7 +335,7 @@ mod tests {
         let toml = render_toml();
         assert_eq!(
             toml.matches("[[kernel]]").count(),
-            MANIFEST.kernels.len(),
+            MANIFEST.len(),
             "one [[kernel]] block per spec"
         );
         assert!(toml.contains("K_QUANT_FORMAT"));

--- a/src/shaders/common/manifest.rs
+++ b/src/shaders/common/manifest.rs
@@ -22,22 +22,29 @@ use scattered_collect::{ScatteredMap, gather};
 #[gather]
 pub static MANIFEST: ScatteredMap<&'static str, &'static KernelSpec>;
 
-/// Scatter one or more `SPEC` consts into [`MANIFEST`], keyed by entry name.
-/// Invoke beside the declarations: `crate::register_kernel_specs!(SPEC);`
+/// Declare a `KernelSpec` const and scatter it into [`MANIFEST`], keyed by
+/// its entry name. Wraps the declaration verbatim, so a spec cannot exist
+/// without being registered:
+///
+/// ```ignore
+/// crate::kernel_spec! {
+///     pub const SPEC: crate::shaders::manifest::KernelSpec = ...;
+/// }
+/// ```
 #[macro_export]
-macro_rules! register_kernel_specs {
-    ($($spec:ident),+ $(,)?) => {
-        $(
-            // The const block scopes the static, so one module can register
-            // several specs without inventing unique names.
-            const _: () = {
-                #[::scattered_collect::scatter($crate::shaders::common::manifest::MANIFEST)]
-                static REG: (
-                    &'static str,
-                    &'static $crate::shaders::common::manifest::KernelSpec,
-                ) = ($spec.entry, &$spec);
-            };
-        )+
+macro_rules! kernel_spec {
+    ($(#[$meta:meta])* $vis:vis const $name:ident: $ty:ty = $spec:expr;) => {
+        $(#[$meta])*
+        $vis const $name: $ty = $spec;
+        // The const block scopes the static, so one module can declare
+        // several specs without inventing unique names.
+        const _: () = {
+            #[::scattered_collect::scatter($crate::shaders::common::manifest::MANIFEST)]
+            static REG: (
+                &'static str,
+                &'static $crate::shaders::common::manifest::KernelSpec,
+            ) = ($name.entry, &$name);
+        };
     };
 }
 

--- a/src/shaders/elementwise/gelu/mod.rs
+++ b/src/shaders/elementwise/gelu/mod.rs
@@ -180,6 +180,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/elementwise/gelu/mod.rs
+++ b/src/shaders/elementwise/gelu/mod.rs
@@ -142,14 +142,15 @@ fn set_bytes<T>(encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>, value: &
 #[cfg(target_os = "macos")]
 use crate::shaders::gpu_common::div_up;
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "gelu",
-    entry: "gelu",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Gelu,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "gelu",
+        entry: "gelu",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Gelu,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -179,5 +180,3 @@ mod tests {
         min_cos = 0.9999,
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/elementwise/gelu/mod.rs
+++ b/src/shaders/elementwise/gelu/mod.rs
@@ -143,13 +143,13 @@ fn set_bytes<T>(encoder: &ProtocolObject<dyn MTLComputeCommandEncoder>, value: &
 use crate::shaders::gpu_common::div_up;
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "gelu",
         entry: "gelu",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Gelu,
-    };
+        variants: KernelVariants::Gelu,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/elementwise/gelu/mod.rs
+++ b/src/shaders/elementwise/gelu/mod.rs
@@ -179,3 +179,7 @@ mod tests {
         min_cos = 0.9999,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/elementwise/rms_norm_rows/mod.rs
+++ b/src/shaders/elementwise/rms_norm_rows/mod.rs
@@ -343,3 +343,7 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
         ],
     },
 };
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/elementwise/rms_norm_rows/mod.rs
+++ b/src/shaders/elementwise/rms_norm_rows/mod.rs
@@ -344,6 +344,4 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     },
 };
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/elementwise/rms_norm_rows/mod.rs
+++ b/src/shaders/elementwise/rms_norm_rows/mod.rs
@@ -330,18 +330,17 @@ mod tests {
 
 pub mod tiled;
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "rms_norm_rows",
-    entry: "rms_norm_rows",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[(4, "K_AFFINE")],
-    variants: crate::shaders::manifest::KernelVariants::RmsNormRows {
-        rows: &[
-            crate::shaders::manifest::RmsNormRowsVariant { affine: false },
-            crate::shaders::manifest::RmsNormRowsVariant { affine: true },
-        ],
-    },
-};
-
-crate::register_kernel_specs!(SPEC);
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "rms_norm_rows",
+        entry: "rms_norm_rows",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[(4, "K_AFFINE")],
+        variants: crate::shaders::manifest::KernelVariants::RmsNormRows {
+            rows: &[
+                crate::shaders::manifest::RmsNormRowsVariant { affine: false },
+                crate::shaders::manifest::RmsNormRowsVariant { affine: true },
+            ],
+        },
+    };
+}

--- a/src/shaders/elementwise/rms_norm_rows/mod.rs
+++ b/src/shaders/elementwise/rms_norm_rows/mod.rs
@@ -331,16 +331,16 @@ mod tests {
 pub mod tiled;
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "rms_norm_rows",
         entry: "rms_norm_rows",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[(4, "K_AFFINE")],
-        variants: crate::shaders::manifest::KernelVariants::RmsNormRows {
+        variants: KernelVariants::RmsNormRows {
             rows: &[
-                crate::shaders::manifest::RmsNormRowsVariant { affine: false },
-                crate::shaders::manifest::RmsNormRowsVariant { affine: true },
+                RmsNormRowsVariant { affine: false },
+                RmsNormRowsVariant { affine: true },
             ],
         },
-    };
+    }
 }

--- a/src/shaders/elementwise/rms_norm_rows/tiled.rs
+++ b/src/shaders/elementwise/rms_norm_rows/tiled.rs
@@ -238,23 +238,24 @@ fn gpu_tiled(f: &Fixture, variant: KernelVariant, tiled: TiledVariant) -> Result
         .collect())
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "rms_norm_rows_tiled",
-    entry: "rms_norm_rows_tiled",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[(4, "K_IN_DTYPE")],
-    variants: crate::shaders::manifest::KernelVariants::RmsNormRowsTiled {
-        rows: &[
-            crate::shaders::manifest::RmsNormRowsTiledVariant {
-                in_dtype: crate::shaders::variant::ElemDtype::F32,
-            },
-            crate::shaders::manifest::RmsNormRowsTiledVariant {
-                in_dtype: crate::shaders::variant::ElemDtype::Half,
-            },
-        ],
-    },
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "rms_norm_rows_tiled",
+        entry: "rms_norm_rows_tiled",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[(4, "K_IN_DTYPE")],
+        variants: crate::shaders::manifest::KernelVariants::RmsNormRowsTiled {
+            rows: &[
+                crate::shaders::manifest::RmsNormRowsTiledVariant {
+                    in_dtype: crate::shaders::variant::ElemDtype::F32,
+                },
+                crate::shaders::manifest::RmsNormRowsTiledVariant {
+                    in_dtype: crate::shaders::variant::ElemDtype::Half,
+                },
+            ],
+        },
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -296,5 +297,3 @@ mod tests {
         min_cos = 0.9999,
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/elementwise/rms_norm_rows/tiled.rs
+++ b/src/shaders/elementwise/rms_norm_rows/tiled.rs
@@ -296,3 +296,7 @@ mod tests {
         min_cos = 0.9999,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/elementwise/rms_norm_rows/tiled.rs
+++ b/src/shaders/elementwise/rms_norm_rows/tiled.rs
@@ -239,22 +239,22 @@ fn gpu_tiled(f: &Fixture, variant: KernelVariant, tiled: TiledVariant) -> Result
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "rms_norm_rows_tiled",
         entry: "rms_norm_rows_tiled",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[(4, "K_IN_DTYPE")],
-        variants: crate::shaders::manifest::KernelVariants::RmsNormRowsTiled {
+        variants: KernelVariants::RmsNormRowsTiled {
             rows: &[
-                crate::shaders::manifest::RmsNormRowsTiledVariant {
-                    in_dtype: crate::shaders::variant::ElemDtype::F32,
+                RmsNormRowsTiledVariant {
+                    in_dtype: ElemDtype::F32,
                 },
-                crate::shaders::manifest::RmsNormRowsTiledVariant {
-                    in_dtype: crate::shaders::variant::ElemDtype::Half,
+                RmsNormRowsTiledVariant {
+                    in_dtype: ElemDtype::Half,
                 },
             ],
         },
-    };
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/elementwise/rms_norm_rows/tiled.rs
+++ b/src/shaders/elementwise/rms_norm_rows/tiled.rs
@@ -297,6 +297,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/elementwise/swiglu/mod.rs
+++ b/src/shaders/elementwise/swiglu/mod.rs
@@ -388,30 +388,29 @@ pub fn gpu_interleaved(f: &InterleavedFixture, variant: KernelVariant) -> Result
 use crate::shaders::gpu_common::div_up;
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "swiglu",
         entry: "swiglu",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[(4, "K_IO_DTYPE"), (5, "K_GELU_GATE"), (6, "K_IN_PLACE")],
-        variants: crate::shaders::manifest::KernelVariants::SwigluSplit {
+        variants: KernelVariants::SwigluSplit {
             rows: &[
-                crate::shaders::manifest::SwigluSplitVariant::DECODER_MUL,
-                crate::shaders::manifest::SwigluSplitVariant::MONOLITH_GLU,
+                SwigluSplitVariant::DECODER_MUL,
+                SwigluSplitVariant::MONOLITH_GLU,
             ],
         },
-    };
+    }
 }
 
 crate::kernel_spec! {
     /// Colocated subkernel registration (swiglu_moe_gate_up.metal).
-    pub const SPEC_MOE_GATE_UP: crate::shaders::manifest::KernelSpec =
-        crate::shaders::manifest::KernelSpec {
-            name: "swiglu_moe_gate_up",
-            entry: "swiglu_moe_gate_up",
-            quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-            fc: &[],
-            variants: crate::shaders::manifest::KernelVariants::SwigluMoeGateUp,
-        };
+    pub const SPEC_MOE_GATE_UP {
+        name: "swiglu_moe_gate_up",
+        entry: "swiglu_moe_gate_up",
+        quant_formats: &[QuantFormat::Q4Affine],
+        fc: &[],
+        variants: KernelVariants::SwigluMoeGateUp,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/elementwise/swiglu/mod.rs
+++ b/src/shaders/elementwise/swiglu/mod.rs
@@ -476,10 +476,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
-
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_MOE_GATE_UP_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC_MOE_GATE_UP.entry, &SPEC_MOE_GATE_UP);
+crate::register_kernel_specs!(SPEC, SPEC_MOE_GATE_UP);

--- a/src/shaders/elementwise/swiglu/mod.rs
+++ b/src/shaders/elementwise/swiglu/mod.rs
@@ -387,29 +387,32 @@ pub fn gpu_interleaved(f: &InterleavedFixture, variant: KernelVariant) -> Result
 #[cfg(target_os = "macos")]
 use crate::shaders::gpu_common::div_up;
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "swiglu",
-    entry: "swiglu",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[(4, "K_IO_DTYPE"), (5, "K_GELU_GATE"), (6, "K_IN_PLACE")],
-    variants: crate::shaders::manifest::KernelVariants::SwigluSplit {
-        rows: &[
-            crate::shaders::manifest::SwigluSplitVariant::DECODER_MUL,
-            crate::shaders::manifest::SwigluSplitVariant::MONOLITH_GLU,
-        ],
-    },
-};
-
-/// Colocated subkernel registration (swiglu_moe_gate_up.metal).
-pub const SPEC_MOE_GATE_UP: crate::shaders::manifest::KernelSpec =
-    crate::shaders::manifest::KernelSpec {
-        name: "swiglu_moe_gate_up",
-        entry: "swiglu_moe_gate_up",
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "swiglu",
+        entry: "swiglu",
         quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-        fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::SwigluMoeGateUp,
+        fc: &[(4, "K_IO_DTYPE"), (5, "K_GELU_GATE"), (6, "K_IN_PLACE")],
+        variants: crate::shaders::manifest::KernelVariants::SwigluSplit {
+            rows: &[
+                crate::shaders::manifest::SwigluSplitVariant::DECODER_MUL,
+                crate::shaders::manifest::SwigluSplitVariant::MONOLITH_GLU,
+            ],
+        },
     };
+}
+
+crate::kernel_spec! {
+    /// Colocated subkernel registration (swiglu_moe_gate_up.metal).
+    pub const SPEC_MOE_GATE_UP: crate::shaders::manifest::KernelSpec =
+        crate::shaders::manifest::KernelSpec {
+            name: "swiglu_moe_gate_up",
+            entry: "swiglu_moe_gate_up",
+            quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+            fc: &[],
+            variants: crate::shaders::manifest::KernelVariants::SwigluMoeGateUp,
+        };
+}
 
 #[cfg(test)]
 mod tests {
@@ -475,5 +478,3 @@ mod tests {
         min_cos = 0.9999,
     }
 }
-
-crate::register_kernel_specs!(SPEC, SPEC_MOE_GATE_UP);

--- a/src/shaders/elementwise/swiglu/mod.rs
+++ b/src/shaders/elementwise/swiglu/mod.rs
@@ -475,3 +475,11 @@ mod tests {
         min_cos = 0.9999,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_MOE_GATE_UP_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC_MOE_GATE_UP.entry, &SPEC_MOE_GATE_UP);

--- a/src/shaders/embed/embed_gather/mod.rs
+++ b/src/shaders/embed/embed_gather/mod.rs
@@ -293,6 +293,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/embed/embed_gather/mod.rs
+++ b/src/shaders/embed/embed_gather/mod.rs
@@ -292,3 +292,7 @@ mod tests {
         min_cos = 0.9999,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/embed/embed_gather/mod.rs
+++ b/src/shaders/embed/embed_gather/mod.rs
@@ -255,14 +255,15 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
         .collect())
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "embed_gather",
-    entry: "embed_gather",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q8],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "embed_gather",
+        entry: "embed_gather",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q8],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -292,5 +293,3 @@ mod tests {
         min_cos = 0.9999,
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/embed/embed_gather/mod.rs
+++ b/src/shaders/embed/embed_gather/mod.rs
@@ -256,13 +256,13 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "embed_gather",
         entry: "embed_gather",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q8],
+        quant_formats: &[QuantFormat::Q8],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/gemm/gemm_linear_f32/mod.rs
+++ b/src/shaders/gemm/gemm_linear_f32/mod.rs
@@ -270,3 +270,7 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     fc: &[],
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/gemm/gemm_linear_f32/mod.rs
+++ b/src/shaders/gemm/gemm_linear_f32/mod.rs
@@ -259,16 +259,15 @@ mod tests {
 
 pub mod cpu;
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "gemm_linear_f32",
-    entry: "gemm_linear_f32",
-    quant_formats: &[
-        crate::shaders::variant::QuantFormat::Q4Affine,
-        crate::shaders::variant::QuantFormat::NvFp4,
-    ],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
-
-crate::register_kernel_specs!(SPEC);
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "gemm_linear_f32",
+        entry: "gemm_linear_f32",
+        quant_formats: &[
+            crate::shaders::variant::QuantFormat::Q4Affine,
+            crate::shaders::variant::QuantFormat::NvFp4,
+        ],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}

--- a/src/shaders/gemm/gemm_linear_f32/mod.rs
+++ b/src/shaders/gemm/gemm_linear_f32/mod.rs
@@ -271,6 +271,4 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/gemm/gemm_linear_f32/mod.rs
+++ b/src/shaders/gemm/gemm_linear_f32/mod.rs
@@ -260,14 +260,14 @@ mod tests {
 pub mod cpu;
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "gemm_linear_f32",
         entry: "gemm_linear_f32",
         quant_formats: &[
-            crate::shaders::variant::QuantFormat::Q4Affine,
-            crate::shaders::variant::QuantFormat::NvFp4,
+            QuantFormat::Q4Affine,
+            QuantFormat::NvFp4,
         ],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }

--- a/src/shaders/gemm/gemm_linear_grouped/mod.rs
+++ b/src/shaders/gemm/gemm_linear_grouped/mod.rs
@@ -523,3 +523,7 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     fc: &[],
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/gemm/gemm_linear_grouped/mod.rs
+++ b/src/shaders/gemm/gemm_linear_grouped/mod.rs
@@ -524,6 +524,4 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/gemm/gemm_linear_grouped/mod.rs
+++ b/src/shaders/gemm/gemm_linear_grouped/mod.rs
@@ -512,16 +512,15 @@ mod tests {
 
 pub mod cpu;
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "gemm_linear_grouped",
-    entry: "gemm_linear_grouped",
-    quant_formats: &[
-        crate::shaders::variant::QuantFormat::Q4Affine,
-        crate::shaders::variant::QuantFormat::NvFp4,
-    ],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
-
-crate::register_kernel_specs!(SPEC);
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "gemm_linear_grouped",
+        entry: "gemm_linear_grouped",
+        quant_formats: &[
+            crate::shaders::variant::QuantFormat::Q4Affine,
+            crate::shaders::variant::QuantFormat::NvFp4,
+        ],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}

--- a/src/shaders/gemm/gemm_linear_grouped/mod.rs
+++ b/src/shaders/gemm/gemm_linear_grouped/mod.rs
@@ -513,14 +513,14 @@ mod tests {
 pub mod cpu;
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "gemm_linear_grouped",
         entry: "gemm_linear_grouped",
         quant_formats: &[
-            crate::shaders::variant::QuantFormat::Q4Affine,
-            crate::shaders::variant::QuantFormat::NvFp4,
+            QuantFormat::Q4Affine,
+            QuantFormat::NvFp4,
         ],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }

--- a/src/shaders/gemm/gemm_q8_linear_f32/mod.rs
+++ b/src/shaders/gemm/gemm_q8_linear_f32/mod.rs
@@ -204,6 +204,4 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/gemm/gemm_q8_linear_f32/mod.rs
+++ b/src/shaders/gemm/gemm_q8_linear_f32/mod.rs
@@ -195,13 +195,12 @@ mod tests {
 
 pub mod kxn;
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "gemm_q8_linear_f32",
-    entry: "gemm_q8_linear_f32",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
-
-crate::register_kernel_specs!(SPEC);
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "gemm_q8_linear_f32",
+        entry: "gemm_q8_linear_f32",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}

--- a/src/shaders/gemm/gemm_q8_linear_f32/mod.rs
+++ b/src/shaders/gemm/gemm_q8_linear_f32/mod.rs
@@ -203,3 +203,7 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     fc: &[],
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/gemm/gemm_q8_linear_f32/mod.rs
+++ b/src/shaders/gemm/gemm_q8_linear_f32/mod.rs
@@ -196,11 +196,11 @@ mod tests {
 pub mod kxn;
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "gemm_q8_linear_f32",
         entry: "gemm_q8_linear_f32",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }

--- a/src/shaders/gemm/gemm_rowk/mod.rs
+++ b/src/shaders/gemm/gemm_rowk/mod.rs
@@ -191,18 +191,18 @@ pub fn gpu(f: &Fixture, _variant: crate::shaders::KernelVariant) -> Result<Vec<f
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "gemm_rowk",
         entry: "gemm_rowk",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q8],
+        quant_formats: &[QuantFormat::Q8],
         fc: &[
             (4, "IS_FULL_LAYER"),
             (5, "GEMM_N"),
             (6, "GEMM_K"),
             (30, "K_ROWK_OUT_ARENA"),
         ],
-        variants: crate::shaders::manifest::KernelVariants::GemmRowk,
-    };
+        variants: KernelVariants::GemmRowk,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/gemm/gemm_rowk/mod.rs
+++ b/src/shaders/gemm/gemm_rowk/mod.rs
@@ -233,6 +233,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/gemm/gemm_rowk/mod.rs
+++ b/src/shaders/gemm/gemm_rowk/mod.rs
@@ -190,19 +190,20 @@ pub fn gpu(f: &Fixture, _variant: crate::shaders::KernelVariant) -> Result<Vec<f
         .collect())
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "gemm_rowk",
-    entry: "gemm_rowk",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q8],
-    fc: &[
-        (4, "IS_FULL_LAYER"),
-        (5, "GEMM_N"),
-        (6, "GEMM_K"),
-        (30, "K_ROWK_OUT_ARENA"),
-    ],
-    variants: crate::shaders::manifest::KernelVariants::GemmRowk,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "gemm_rowk",
+        entry: "gemm_rowk",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q8],
+        fc: &[
+            (4, "IS_FULL_LAYER"),
+            (5, "GEMM_N"),
+            (6, "GEMM_K"),
+            (30, "K_ROWK_OUT_ARENA"),
+        ],
+        variants: crate::shaders::manifest::KernelVariants::GemmRowk,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -232,5 +233,3 @@ mod tests {
         min_cos = 0.999,
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/gemm/gemm_rowk/mod.rs
+++ b/src/shaders/gemm/gemm_rowk/mod.rs
@@ -232,3 +232,7 @@ mod tests {
         min_cos = 0.999,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/moe/moe_bucket_count/mod.rs
+++ b/src/shaders/moe/moe_bucket_count/mod.rs
@@ -146,3 +146,7 @@ mod tests {
         min_cos = 1.0,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/moe/moe_bucket_count/mod.rs
+++ b/src/shaders/moe/moe_bucket_count/mod.rs
@@ -121,14 +121,15 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
         .collect())
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "moe_bucket_count",
-    entry: "moe_bucket_count",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "moe_bucket_count",
+        entry: "moe_bucket_count",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -146,5 +147,3 @@ mod tests {
         min_cos = 1.0,
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/moe/moe_bucket_count/mod.rs
+++ b/src/shaders/moe/moe_bucket_count/mod.rs
@@ -147,6 +147,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/moe/moe_bucket_count/mod.rs
+++ b/src/shaders/moe/moe_bucket_count/mod.rs
@@ -122,13 +122,13 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "moe_bucket_count",
         entry: "moe_bucket_count",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/moe/moe_bucket_fill/mod.rs
+++ b/src/shaders/moe/moe_bucket_fill/mod.rs
@@ -262,3 +262,7 @@ mod tests {
         min_cos = 1.0,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/moe/moe_bucket_fill/mod.rs
+++ b/src/shaders/moe/moe_bucket_fill/mod.rs
@@ -263,6 +263,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/moe/moe_bucket_fill/mod.rs
+++ b/src/shaders/moe/moe_bucket_fill/mod.rs
@@ -225,14 +225,15 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
     Ok(out)
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "moe_bucket_fill",
-    entry: "moe_bucket_fill",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "moe_bucket_fill",
+        entry: "moe_bucket_fill",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -262,5 +263,3 @@ mod tests {
         min_cos = 1.0,
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/moe/moe_bucket_fill/mod.rs
+++ b/src/shaders/moe/moe_bucket_fill/mod.rs
@@ -226,13 +226,13 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "moe_bucket_fill",
         entry: "moe_bucket_fill",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/moe/moe_grouped/mod.rs
+++ b/src/shaders/moe/moe_grouped/mod.rs
@@ -436,3 +436,7 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     fc: &[],
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/moe/moe_grouped/mod.rs
+++ b/src/shaders/moe/moe_grouped/mod.rs
@@ -437,6 +437,4 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/moe/moe_grouped/mod.rs
+++ b/src/shaders/moe/moe_grouped/mod.rs
@@ -425,16 +425,15 @@ mod tests {
 pub mod cpu;
 pub mod nvfp4;
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "moe_grouped",
-    entry: "moe_grouped",
-    quant_formats: &[
-        crate::shaders::variant::QuantFormat::Q4Affine,
-        crate::shaders::variant::QuantFormat::NvFp4,
-    ],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
-
-crate::register_kernel_specs!(SPEC);
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "moe_grouped",
+        entry: "moe_grouped",
+        quant_formats: &[
+            crate::shaders::variant::QuantFormat::Q4Affine,
+            crate::shaders::variant::QuantFormat::NvFp4,
+        ],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}

--- a/src/shaders/moe/moe_grouped/mod.rs
+++ b/src/shaders/moe/moe_grouped/mod.rs
@@ -426,14 +426,14 @@ pub mod cpu;
 pub mod nvfp4;
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "moe_grouped",
         entry: "moe_grouped",
         quant_formats: &[
-            crate::shaders::variant::QuantFormat::Q4Affine,
-            crate::shaders::variant::QuantFormat::NvFp4,
+            QuantFormat::Q4Affine,
+            QuantFormat::NvFp4,
         ],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }

--- a/src/shaders/moe/moe_router/mod.rs
+++ b/src/shaders/moe/moe_router/mod.rs
@@ -329,3 +329,7 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     fc: &[],
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/moe/moe_router/mod.rs
+++ b/src/shaders/moe/moe_router/mod.rs
@@ -330,6 +330,4 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/moe/moe_router/mod.rs
+++ b/src/shaders/moe/moe_router/mod.rs
@@ -321,13 +321,12 @@ pub mod cpu;
 pub const TOPK_ENTRY: &str = "moe_router_topk";
 pub const TOPK_SHADER: &str = include_str!("moe_router_topk.metal");
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "moe_router",
-    entry: "moe_router",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
-
-crate::register_kernel_specs!(SPEC);
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "moe_router",
+        entry: "moe_router",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}

--- a/src/shaders/moe/moe_router/mod.rs
+++ b/src/shaders/moe/moe_router/mod.rs
@@ -322,11 +322,11 @@ pub const TOPK_ENTRY: &str = "moe_router_topk";
 pub const TOPK_SHADER: &str = include_str!("moe_router_topk.metal");
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "moe_router",
         entry: "moe_router",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }

--- a/src/shaders/moe/moe_scatter_weighted/mod.rs
+++ b/src/shaders/moe/moe_scatter_weighted/mod.rs
@@ -221,11 +221,11 @@ mod tests {
 pub mod cpu;
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "moe_scatter_weighted",
         entry: "moe_scatter_weighted",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }

--- a/src/shaders/moe/moe_scatter_weighted/mod.rs
+++ b/src/shaders/moe/moe_scatter_weighted/mod.rs
@@ -228,3 +228,7 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     fc: &[],
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/moe/moe_scatter_weighted/mod.rs
+++ b/src/shaders/moe/moe_scatter_weighted/mod.rs
@@ -229,6 +229,4 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/moe/moe_scatter_weighted/mod.rs
+++ b/src/shaders/moe/moe_scatter_weighted/mod.rs
@@ -220,13 +220,12 @@ mod tests {
 
 pub mod cpu;
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "moe_scatter_weighted",
-    entry: "moe_scatter_weighted",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
-
-crate::register_kernel_specs!(SPEC);
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "moe_scatter_weighted",
+        entry: "moe_scatter_weighted",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}

--- a/src/shaders/oracle/gemm/gemm_block/mod.rs
+++ b/src/shaders/oracle/gemm/gemm_block/mod.rs
@@ -3,17 +3,16 @@
 pub const ENTRY: &str = "gemm_block";
 pub const SHADER: &str = include_str!("gemm_block.metal");
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "gemm_block",
-    entry: "gemm_block",
-    quant_formats: &[
-        crate::shaders::variant::QuantFormat::Q4Affine,
-        crate::shaders::variant::QuantFormat::Q8,
-        crate::shaders::variant::QuantFormat::NvFp4,
-    ],
-    fc: &[(4, "IS_FULL_LAYER"), (5, "GEMM_N"), (6, "GEMM_K")],
-    variants: crate::shaders::manifest::KernelVariants::GemmBlock,
-};
-
-crate::register_kernel_specs!(SPEC);
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "gemm_block",
+        entry: "gemm_block",
+        quant_formats: &[
+            crate::shaders::variant::QuantFormat::Q4Affine,
+            crate::shaders::variant::QuantFormat::Q8,
+            crate::shaders::variant::QuantFormat::NvFp4,
+        ],
+        fc: &[(4, "IS_FULL_LAYER"), (5, "GEMM_N"), (6, "GEMM_K")],
+        variants: crate::shaders::manifest::KernelVariants::GemmBlock,
+    };
+}

--- a/src/shaders/oracle/gemm/gemm_block/mod.rs
+++ b/src/shaders/oracle/gemm/gemm_block/mod.rs
@@ -16,6 +16,4 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     variants: crate::shaders::manifest::KernelVariants::GemmBlock,
 };
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/oracle/gemm/gemm_block/mod.rs
+++ b/src/shaders/oracle/gemm/gemm_block/mod.rs
@@ -4,15 +4,15 @@ pub const ENTRY: &str = "gemm_block";
 pub const SHADER: &str = include_str!("gemm_block.metal");
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "gemm_block",
         entry: "gemm_block",
         quant_formats: &[
-            crate::shaders::variant::QuantFormat::Q4Affine,
-            crate::shaders::variant::QuantFormat::Q8,
-            crate::shaders::variant::QuantFormat::NvFp4,
+            QuantFormat::Q4Affine,
+            QuantFormat::Q8,
+            QuantFormat::NvFp4,
         ],
         fc: &[(4, "IS_FULL_LAYER"), (5, "GEMM_N"), (6, "GEMM_K")],
-        variants: crate::shaders::manifest::KernelVariants::GemmBlock,
-    };
+        variants: KernelVariants::GemmBlock,
+    }
 }

--- a/src/shaders/oracle/gemm/gemm_block/mod.rs
+++ b/src/shaders/oracle/gemm/gemm_block/mod.rs
@@ -15,3 +15,7 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     fc: &[(4, "IS_FULL_LAYER"), (5, "GEMM_N"), (6, "GEMM_K")],
     variants: crate::shaders::manifest::KernelVariants::GemmBlock,
 };
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/oracle/gemm/gemm_block_grouped/mod.rs
+++ b/src/shaders/oracle/gemm/gemm_block_grouped/mod.rs
@@ -362,17 +362,18 @@ pub fn gpu_on_blob(
     Ok(out)
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "gemm_block_grouped",
-    entry: "gemm_block_grouped",
-    quant_formats: &[
-        crate::shaders::variant::QuantFormat::Q4Affine,
-        crate::shaders::variant::QuantFormat::NvFp4,
-    ],
-    fc: &[(4, "IS_FULL_LAYER"), (5, "GEMM_N"), (6, "GEMM_K")],
-    variants: crate::shaders::manifest::KernelVariants::GemmBlock,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "gemm_block_grouped",
+        entry: "gemm_block_grouped",
+        quant_formats: &[
+            crate::shaders::variant::QuantFormat::Q4Affine,
+            crate::shaders::variant::QuantFormat::NvFp4,
+        ],
+        fc: &[(4, "IS_FULL_LAYER"), (5, "GEMM_N"), (6, "GEMM_K")],
+        variants: crate::shaders::manifest::KernelVariants::GemmBlock,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -426,5 +427,3 @@ mod tests {
         min_cos = 0.999,
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/oracle/gemm/gemm_block_grouped/mod.rs
+++ b/src/shaders/oracle/gemm/gemm_block_grouped/mod.rs
@@ -426,3 +426,7 @@ mod tests {
         min_cos = 0.999,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/oracle/gemm/gemm_block_grouped/mod.rs
+++ b/src/shaders/oracle/gemm/gemm_block_grouped/mod.rs
@@ -363,16 +363,16 @@ pub fn gpu_on_blob(
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "gemm_block_grouped",
         entry: "gemm_block_grouped",
         quant_formats: &[
-            crate::shaders::variant::QuantFormat::Q4Affine,
-            crate::shaders::variant::QuantFormat::NvFp4,
+            QuantFormat::Q4Affine,
+            QuantFormat::NvFp4,
         ],
         fc: &[(4, "IS_FULL_LAYER"), (5, "GEMM_N"), (6, "GEMM_K")],
-        variants: crate::shaders::manifest::KernelVariants::GemmBlock,
-    };
+        variants: KernelVariants::GemmBlock,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/oracle/gemm/gemm_block_grouped/mod.rs
+++ b/src/shaders/oracle/gemm/gemm_block_grouped/mod.rs
@@ -427,6 +427,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/oracle/gemm/gemm_block_stacked/mod.rs
+++ b/src/shaders/oracle/gemm/gemm_block_stacked/mod.rs
@@ -1018,3 +1018,7 @@ mod tests {
         assert!(max < 0.05, "dgq qkv stacked vs split max_abs={max}");
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/oracle/gemm/gemm_block_stacked/mod.rs
+++ b/src/shaders/oracle/gemm/gemm_block_stacked/mod.rs
@@ -644,17 +644,18 @@ pub fn qkv_sliding_prod_fixture(_: ElemFormat) -> StackedFixture {
     }
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "gemm_block_stacked",
-    entry: "gemm_block_stacked",
-    quant_formats: &[
-        crate::shaders::variant::QuantFormat::Q4Affine,
-        crate::shaders::variant::QuantFormat::NvFp4,
-    ],
-    fc: &[(4, "IS_FULL_LAYER"), (5, "GEMM_N"), (6, "GEMM_K")],
-    variants: crate::shaders::manifest::KernelVariants::GemmBlock,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "gemm_block_stacked",
+        entry: "gemm_block_stacked",
+        quant_formats: &[
+            crate::shaders::variant::QuantFormat::Q4Affine,
+            crate::shaders::variant::QuantFormat::NvFp4,
+        ],
+        fc: &[(4, "IS_FULL_LAYER"), (5, "GEMM_N"), (6, "GEMM_K")],
+        variants: crate::shaders::manifest::KernelVariants::GemmBlock,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -1018,5 +1019,3 @@ mod tests {
         assert!(max < 0.05, "dgq qkv stacked vs split max_abs={max}");
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/oracle/gemm/gemm_block_stacked/mod.rs
+++ b/src/shaders/oracle/gemm/gemm_block_stacked/mod.rs
@@ -645,16 +645,16 @@ pub fn qkv_sliding_prod_fixture(_: ElemFormat) -> StackedFixture {
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "gemm_block_stacked",
         entry: "gemm_block_stacked",
         quant_formats: &[
-            crate::shaders::variant::QuantFormat::Q4Affine,
-            crate::shaders::variant::QuantFormat::NvFp4,
+            QuantFormat::Q4Affine,
+            QuantFormat::NvFp4,
         ],
         fc: &[(4, "IS_FULL_LAYER"), (5, "GEMM_N"), (6, "GEMM_K")],
-        variants: crate::shaders::manifest::KernelVariants::GemmBlock,
-    };
+        variants: KernelVariants::GemmBlock,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/oracle/gemm/gemm_block_stacked/mod.rs
+++ b/src/shaders/oracle/gemm/gemm_block_stacked/mod.rs
@@ -1019,6 +1019,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/sample/logit_rowstats/mod.rs
+++ b/src/shaders/sample/logit_rowstats/mod.rs
@@ -137,14 +137,15 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
     Ok(out)
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "logit_rowstats",
-    entry: "logit_rowstats",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "logit_rowstats",
+        entry: "logit_rowstats",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -174,5 +175,3 @@ mod tests {
         min_cos = 0.9999,
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/sample/logit_rowstats/mod.rs
+++ b/src/shaders/sample/logit_rowstats/mod.rs
@@ -175,6 +175,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/sample/logit_rowstats/mod.rs
+++ b/src/shaders/sample/logit_rowstats/mod.rs
@@ -174,3 +174,7 @@ mod tests {
         min_cos = 0.9999,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/sample/logit_rowstats/mod.rs
+++ b/src/shaders/sample/logit_rowstats/mod.rs
@@ -138,13 +138,13 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "logit_rowstats",
         entry: "logit_rowstats",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/sample/sample_apply/mod.rs
+++ b/src/shaders/sample/sample_apply/mod.rs
@@ -288,6 +288,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/sample/sample_apply/mod.rs
+++ b/src/shaders/sample/sample_apply/mod.rs
@@ -250,14 +250,15 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
     Ok(picks.iter().map(|&v| v as f32).collect())
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "sample_apply",
-    entry: "sample_apply",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "sample_apply",
+        entry: "sample_apply",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -287,5 +288,3 @@ mod tests {
         min_cos = 0.9999,
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/sample/sample_apply/mod.rs
+++ b/src/shaders/sample/sample_apply/mod.rs
@@ -251,13 +251,13 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "sample_apply",
         entry: "sample_apply",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/sample/sample_apply/mod.rs
+++ b/src/shaders/sample/sample_apply/mod.rs
@@ -287,3 +287,7 @@ mod tests {
         min_cos = 0.9999,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/sample/sample_commit/mod.rs
+++ b/src/shaders/sample/sample_commit/mod.rs
@@ -259,13 +259,13 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "sample_commit",
         entry: "sample_commit",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/sample/sample_commit/mod.rs
+++ b/src/shaders/sample/sample_commit/mod.rs
@@ -258,14 +258,15 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
     Ok(pack_out(&state_out, f.canvas_size))
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "sample_commit",
-    entry: "sample_commit",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "sample_commit",
+        entry: "sample_commit",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -295,5 +296,3 @@ mod tests {
         min_cos = 0.9999,
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/sample/sample_commit/mod.rs
+++ b/src/shaders/sample/sample_commit/mod.rs
@@ -296,6 +296,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/sample/sample_commit/mod.rs
+++ b/src/shaders/sample/sample_commit/mod.rs
@@ -295,3 +295,7 @@ mod tests {
         min_cos = 0.9999,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/sample/sample_rowstats/mod.rs
+++ b/src/shaders/sample/sample_rowstats/mod.rs
@@ -315,3 +315,7 @@ mod tests {
         min_cos = 0.9999,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/sample/sample_rowstats/mod.rs
+++ b/src/shaders/sample/sample_rowstats/mod.rs
@@ -266,14 +266,15 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
     Ok(pack_out(&rowstat, &entropy, &prev))
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "sample_rowstats",
-    entry: "sample_rowstats",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "sample_rowstats",
+        entry: "sample_rowstats",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -315,5 +316,3 @@ mod tests {
         min_cos = 0.9999,
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/sample/sample_rowstats/mod.rs
+++ b/src/shaders/sample/sample_rowstats/mod.rs
@@ -267,13 +267,13 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "sample_rowstats",
         entry: "sample_rowstats",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/sample/sample_rowstats/mod.rs
+++ b/src/shaders/sample/sample_rowstats/mod.rs
@@ -316,6 +316,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/sample/sample_write/mod.rs
+++ b/src/shaders/sample/sample_write/mod.rs
@@ -178,14 +178,15 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
     Ok(out)
 }
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "sample_write",
-    entry: "sample_write",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "sample_write",
+        entry: "sample_write",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}
 
 #[cfg(test)]
 mod tests {
@@ -215,5 +216,3 @@ mod tests {
         min_cos = 1.0,
     }
 }
-
-crate::register_kernel_specs!(SPEC);

--- a/src/shaders/sample/sample_write/mod.rs
+++ b/src/shaders/sample/sample_write/mod.rs
@@ -179,13 +179,13 @@ pub fn gpu(f: &Fixture, variant: KernelVariant) -> Result<Vec<f32>, Error> {
 }
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "sample_write",
         entry: "sample_write",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }
 
 #[cfg(test)]

--- a/src/shaders/sample/sample_write/mod.rs
+++ b/src/shaders/sample/sample_write/mod.rs
@@ -216,6 +216,4 @@ mod tests {
     }
 }
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/sample/sample_write/mod.rs
+++ b/src/shaders/sample/sample_write/mod.rs
@@ -215,3 +215,7 @@ mod tests {
         min_cos = 1.0,
     }
 }
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/sc/sc_prob_cols/mod.rs
+++ b/src/shaders/sc/sc_prob_cols/mod.rs
@@ -234,6 +234,4 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
 
-#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
-static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
-    (SPEC.entry, &SPEC);
+crate::register_kernel_specs!(SPEC);

--- a/src/shaders/sc/sc_prob_cols/mod.rs
+++ b/src/shaders/sc/sc_prob_cols/mod.rs
@@ -233,3 +233,7 @@ pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest:
     fc: &[],
     variants: crate::shaders::manifest::KernelVariants::Elementwise,
 };
+
+#[scattered_collect::scatter(crate::shaders::common::manifest::MANIFEST)]
+static SPEC_REG: (&'static str, &'static crate::shaders::manifest::KernelSpec) =
+    (SPEC.entry, &SPEC);

--- a/src/shaders/sc/sc_prob_cols/mod.rs
+++ b/src/shaders/sc/sc_prob_cols/mod.rs
@@ -226,11 +226,11 @@ mod tests {
 pub mod cpu;
 
 crate::kernel_spec! {
-    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+    pub const SPEC {
         name: "sc_prob_cols",
         entry: "sc_prob_cols",
-        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        quant_formats: &[QuantFormat::Q4Affine],
         fc: &[],
-        variants: crate::shaders::manifest::KernelVariants::Elementwise,
-    };
+        variants: KernelVariants::Elementwise,
+    }
 }

--- a/src/shaders/sc/sc_prob_cols/mod.rs
+++ b/src/shaders/sc/sc_prob_cols/mod.rs
@@ -225,13 +225,12 @@ mod tests {
 
 pub mod cpu;
 
-/// Manifest registration; collected in common/manifest.rs::MANIFEST.
-pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
-    name: "sc_prob_cols",
-    entry: "sc_prob_cols",
-    quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
-    fc: &[],
-    variants: crate::shaders::manifest::KernelVariants::Elementwise,
-};
-
-crate::register_kernel_specs!(SPEC);
+crate::kernel_spec! {
+    pub const SPEC: crate::shaders::manifest::KernelSpec = crate::shaders::manifest::KernelSpec {
+        name: "sc_prob_cols",
+        entry: "sc_prob_cols",
+        quant_formats: &[crate::shaders::variant::QuantFormat::Q4Affine],
+        fc: &[],
+        variants: crate::shaders::manifest::KernelVariants::Elementwise,
+    };
+}


### PR DESCRIPTION
## What

Replaces the two hand-maintained shader registries with link-time collections built on `scattered-collect`:

- **Includes**: gpukit gains `register_includes!("<folder>")` — `include_dir!` embedding combined with a scatter site into a gathered `ScatteredSlice`. diffgemma's 21-row `INCLUDES` table becomes one line, `ContextConfig` disappears (`Context::new` takes `CacheConfig` directly), and the Metal context resolves `#include` against the union of registered folders, failing loud on a basename registered by two folders. The `include_table_matches_dir` drift test is deleted because the invariant it policed can no longer be violated.
- **Kernel manifest**: `MANIFEST` becomes a gathered `ScatteredMap<&str, &KernelSpec>` keyed by entry name. Each of the 28 `SPEC`s scatters itself beside its declaration (uniform 4-line block per kernel file); the 28-row central list is deleted. `spec_by_entry` is a map lookup; `render_toml` sorts by name so `diffgemma manifest` output is deterministic; the uniqueness test iterates `entries()` (raw scatter records), so a duplicate registration stays visible even where lookup would shadow it.

## Why

Adding a kernel or header previously meant editing the definition site *and* remembering a central row, with a test whose only job was catching the forgotten half. Registration at the definition site deletes the failure mode instead of policing it. The cross-crate design also lines up with the planned kernel-library split: a gather declared in gpukit collects scatter sites from any downstream crate — the include registry already works this way, verified with no direct `scattered-collect` dependency in the consumer path.

## Reviewer notes

- `register_includes!` captures `$path:tt` (not `$path:literal`) — a literal metavariable reaches `include_dir!` wrapped in an invisible group and its parser rejects it. The macro body aliases gpukit's `include_dir` re-export into scope because the proc macro emits paths naming its own crate.
- The manifest gather uses the proc-macro `#[gather]` attribute form. A detour in this branch's history came from invoking the root (attribute) `gather` bang-style — wrong usage with a misleading error cascade; a DX writeup for the linktime repo came out of it.
- `diffgemma manifest` renders the same 28 kernels as before; registration is a faithful translation of the old central list (28 `SPEC` consts found = 28 rows registered).

## Gates

- Full suite: diffgemma 786 passed / 0 failed (one fewer test: the deleted drift test), gpukit 4/4
- `golden`: 8/8 byte-identical
- build / clippy / fmt: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
