### PR TITLE
Model de-hardcoding: config-derived dims through the step kernel

### DIFF
--- a/crates/gpukit/src/metal/context.rs
+++ b/crates/gpukit/src/metal/context.rs
@@ -33,6 +33,7 @@ pub struct FcValues {
     bools: Vec<(u32, bool)>,
     uints: Vec<(u32, u32)>,
     ulongs: Vec<(u32, u64)>,
+    floats: Vec<(u32, f32)>,
 }
 
 impl FcValues {
@@ -52,6 +53,11 @@ impl FcValues {
 
     pub fn set_ulong(&mut self, index: u32, value: u64) -> &mut Self {
         self.ulongs.push((index, value));
+        self
+    }
+
+    pub fn set_float(&mut self, index: u32, value: f32) -> &mut Self {
+        self.floats.push((index, value));
         self
     }
 
@@ -78,6 +84,13 @@ impl FcValues {
                     *index as usize,
                 );
             }
+            for (index, value) in &self.floats {
+                fc.setConstantValue_type_atIndex(
+                    std::ptr::NonNull::from_ref(value).cast(),
+                    MTLDataType::Float,
+                    *index as usize,
+                );
+            }
         }
     }
 
@@ -92,6 +105,9 @@ impl FcValues {
         }
         for (index, value) in &self.ulongs {
             let _ = write!(s, "_l{index}={value}");
+        }
+        for (index, value) in &self.floats {
+            let _ = write!(s, "_f{index}={:08x}", value.to_bits());
         }
         s
     }

--- a/src/metal/device.rs
+++ b/src/metal/device.rs
@@ -137,6 +137,29 @@ impl MetalContext {
         extra_bools: &[crate::shaders::variant::FcBool],
         extra_uints: &[crate::shaders::variant::FcUInt],
     ) -> Result<ComputePipeline, Error> {
+        self.compile_subkernel_ex_floats(
+            source,
+            entry,
+            variant,
+            extra_label,
+            extra_bools,
+            extra_uints,
+            &[],
+        )
+    }
+
+    /// As `compile_subkernel_ex` with float axes (e.g. RoPE theta).
+    #[allow(clippy::too_many_arguments)]
+    pub fn compile_subkernel_ex_floats(
+        &self,
+        source: &str,
+        entry: &str,
+        variant: KernelVariant,
+        extra_label: &str,
+        extra_bools: &[crate::shaders::variant::FcBool],
+        extra_uints: &[crate::shaders::variant::FcUInt],
+        extra_floats: &[crate::shaders::variant::FcFloat],
+    ) -> Result<ComputePipeline, Error> {
         let mut fc = gk::FcValues::new();
         fc.set_bool(1, variant.shape_assert)
             .set_uint(2, variant.dump_stage)
@@ -149,6 +172,9 @@ impl MetalContext {
         }
         for extra in extra_uints {
             fc.set_uint(extra.index, extra.value);
+        }
+        for extra in extra_floats {
+            fc.set_float(extra.index, extra.value);
         }
         let label = variant.cache_label_extra(entry, extra_label);
         Ok(self.inner.compile_specialized(source, entry, &fc, &label)?)

--- a/src/metal/mod.rs
+++ b/src/metal/mod.rs
@@ -86,16 +86,16 @@ pub use gemm::{Bf16Gemm, bf16_matmul_cpu, f32_to_bf16};
 pub use kv_cache::GpuKvCache;
 pub use probe::{print_probe_result, probe_device};
 pub use step_attn_dump::{run_step_attn_layer_dump, write_step_attn_layer_dump};
-pub use step_config::{log_validated_step_model, validate_step_model};
+pub use step_config::{ModelDims, log_validated_step_model, validate_step_model};
 pub use step_generate::{
     BlockOutcome, CancelToken, KvSnapshot, ProposedBlock, StepGenerateConfig, StepGenerateSession,
     StepObserver, TurnState, begin_turn, commit_block, finish_turn, generate_monolithic,
     generate_with_session, propose_block,
 };
 pub use step_kernel::{
-    CANVAS, CanvasState, EncodeSubProfileResult, FROZEN_WORDS, HID, LayerEncodeSubProfile,
-    LayerOffsets, MOE_FF, MOE_MAX_BLOCKS, MoeEncodeSubProfile, N_EXPERTS, PREFILL_M, PREFILL_SUBS,
-    RouteScratch, StepFinishMode, StepParams, StepSmokeConfig, TOP_K, bench_fused_gemm_dispatches,
+    CANVAS, CanvasState, EncodeSubProfileResult, FROZEN_WORDS, LayerEncodeSubProfile, LayerOffsets,
+    MOE_FF, MOE_MAX_BLOCKS, MoeEncodeSubProfile, N_EXPERTS, PREFILL_M, PREFILL_SUBS, RouteScratch,
+    StepFinishMode, StepParams, StepSmokeConfig, TOP_K, bench_fused_gemm_dispatches,
     bench_step_kernel, bench_step_kernel_encode_subprofile, bench_step_kernel_prefill_super,
     bench_step_kernel_prefill_super_stages, bench_step_kernel_profile,
     bench_step_kernel_profile_steps, fill_token_slot, layer_moe_block_jobs, run_embed_row_gpu,

--- a/src/metal/step_config.rs
+++ b/src/metal/step_config.rs
@@ -124,9 +124,39 @@ impl ModelDims {
         self.canvas * self.prefill_subs
     }
 
-    /// u32 words in the sampler's per-canvas accept bitmask.
-    pub fn frozen_words(&self) -> usize {
-        self.canvas / 32
+    /// Stable hash over every field, for cache keys that must distinguish
+    /// models (the process-global step-pipeline cache).
+    pub fn fingerprint(&self) -> u64 {
+        let mut h: u64 = 0xcbf29ce484222325;
+        let mut eat = |v: u64| {
+            for b in v.to_le_bytes() {
+                h ^= b as u64;
+                h = h.wrapping_mul(0x100000001b3);
+            }
+        };
+        for v in [
+            self.hid,
+            self.vocab,
+            self.canvas,
+            self.n_layers,
+            self.dense_ff,
+            self.moe_ff,
+            self.n_experts,
+            self.top_k,
+            self.n_q_heads,
+            self.sliding_kv_heads,
+            self.sliding_head_dim,
+            self.full_kv_heads,
+            self.full_head_dim,
+            self.prefill_subs,
+        ] {
+            eat(v as u64);
+        }
+        for &l in &self.full_layers {
+            eat(l as u64);
+        }
+        eat(self.rms_eps.to_bits());
+        h
     }
 }
 
@@ -279,7 +309,7 @@ mod tests {
         assert_eq!(d.top_k, sk::TOP_K);
         assert_eq!(d.full_layers, sk::FULL_LAYERS);
         assert_eq!(d.prefill_m(), sk::PREFILL_M);
-        assert_eq!(d.frozen_words(), sk::FROZEN_WORDS);
+        assert_eq!(d.canvas / 32, sk::FROZEN_WORDS);
         // The head-geometry literals in enc.rs and the pipeline shape list.
         assert_eq!(d.q_cols(false), 4096);
         assert_eq!(d.q_cols(true), 8192);

--- a/src/metal/step_config.rs
+++ b/src/metal/step_config.rs
@@ -13,6 +13,121 @@ pub struct ValidatedStepModel {
     pub canvas_length: usize,
     pub vocab_size: usize,
     pub hidden_size: usize,
+    pub dims: ModelDims,
+}
+
+/// Model geometry derived from `config.json`, threaded through the step
+/// runtime in place of the compile-time constants. While the constants
+/// exist, `validate_step_model` guarantees the two agree; the constants are
+/// removed consumer by consumer.
+#[derive(Debug, Clone)]
+pub struct ModelDims {
+    pub hid: usize,
+    pub vocab: usize,
+    pub canvas: usize,
+    pub n_layers: usize,
+    pub dense_ff: usize,
+    pub moe_ff: usize,
+    pub n_experts: usize,
+    pub top_k: usize,
+    pub n_q_heads: usize,
+    pub sliding_kv_heads: usize,
+    pub sliding_head_dim: usize,
+    pub full_kv_heads: usize,
+    pub full_head_dim: usize,
+    /// Layer indices with full (global) attention; the rest slide.
+    pub full_layers: Vec<usize>,
+    pub rms_eps: f64,
+    /// Causal sub-chunks batched into one prefill forward (see PREFILL_SUBS).
+    pub prefill_subs: usize,
+}
+
+impl ModelDims {
+    /// The reference checkpoint's geometry, for test and audit helpers that
+    /// run without a `config.json`. Production paths derive dims from config.
+    pub fn reference() -> Self {
+        use crate::metal::step_kernel as sk;
+        Self {
+            hid: sk::HID,
+            vocab: sk::VOCAB,
+            canvas: sk::CANVAS,
+            n_layers: sk::N_LAYERS,
+            dense_ff: sk::DENSE_FF as usize,
+            moe_ff: sk::MOE_FF as usize,
+            n_experts: sk::N_EXPERTS,
+            top_k: sk::TOP_K,
+            n_q_heads: 16,
+            sliding_kv_heads: 8,
+            sliding_head_dim: 256,
+            full_kv_heads: 2,
+            full_head_dim: 512,
+            full_layers: sk::FULL_LAYERS.to_vec(),
+            rms_eps: 1e-6,
+            prefill_subs: sk::PREFILL_SUBS,
+        }
+    }
+
+    pub fn from_config(cfg: &ModelConfig) -> Self {
+        let t = &cfg.text_config;
+        Self {
+            hid: t.hidden_size,
+            vocab: t.vocab_size,
+            canvas: cfg.canvas_length,
+            n_layers: t.num_hidden_layers,
+            dense_ff: t.intermediate_size,
+            moe_ff: t.moe_intermediate_size,
+            n_experts: t.num_experts,
+            top_k: t.top_k_experts,
+            n_q_heads: t.num_attention_heads,
+            sliding_kv_heads: t.num_key_value_heads,
+            sliding_head_dim: t.head_dim,
+            full_kv_heads: t.num_global_key_value_heads,
+            full_head_dim: t.global_head_dim,
+            full_layers: full_layers_from_config(&t.layer_types),
+            rms_eps: t.rms_norm_eps,
+            prefill_subs: crate::metal::step_kernel::PREFILL_SUBS,
+        }
+    }
+
+    pub fn is_full_layer(&self, layer: usize) -> bool {
+        self.full_layers.contains(&layer)
+    }
+
+    pub fn head_dim(&self, full: bool) -> usize {
+        if full {
+            self.full_head_dim
+        } else {
+            self.sliding_head_dim
+        }
+    }
+
+    pub fn kv_heads(&self, full: bool) -> usize {
+        if full {
+            self.full_kv_heads
+        } else {
+            self.sliding_kv_heads
+        }
+    }
+
+    /// Q-projection output width: every query head at this layer kind's dim.
+    pub fn q_cols(&self, full: bool) -> usize {
+        self.n_q_heads * self.head_dim(full)
+    }
+
+    /// K (= V) projection output width.
+    pub fn kv_cols(&self, full: bool) -> usize {
+        self.kv_heads(full) * self.head_dim(full)
+    }
+
+    /// Rows per batched-prefill super-chunk forward.
+    pub fn prefill_m(&self) -> usize {
+        self.canvas * self.prefill_subs
+    }
+
+    /// u32 words in the sampler's per-canvas accept bitmask.
+    pub fn frozen_words(&self) -> usize {
+        self.canvas / 32
+    }
 }
 
 fn mismatch(field: &str, config: usize, shader: usize) -> Error {
@@ -116,6 +231,7 @@ pub fn validate_step_model(model_dir: &Path) -> Result<ValidatedStepModel, Error
         canvas_length: cfg.canvas_length,
         vocab_size: t.vocab_size,
         hidden_size: t.hidden_size,
+        dims: ModelDims::from_config(&cfg),
     })
 }
 
@@ -141,5 +257,35 @@ mod tests {
         let v = validate_step_model(dir).expect("default config should match shader");
         assert_eq!(v.num_layers, 30);
         assert_eq!(v.canvas_length, 256);
+    }
+
+    /// The derived geometry must reproduce every value the step kernel
+    /// hardcodes today; consumers switch from the constants to these.
+    #[test]
+    fn dims_reproduce_shader_constants() {
+        use crate::metal::step_kernel as sk;
+        let dir = Path::new("model/transformer");
+        if !dir.join("config.json").exists() {
+            return;
+        }
+        let d = validate_step_model(dir).expect("reference config").dims;
+        assert_eq!(d.hid, sk::HID);
+        assert_eq!(d.vocab, sk::VOCAB);
+        assert_eq!(d.canvas, sk::CANVAS);
+        assert_eq!(d.n_layers, sk::N_LAYERS);
+        assert_eq!(d.dense_ff, sk::DENSE_FF as usize);
+        assert_eq!(d.moe_ff, sk::MOE_FF as usize);
+        assert_eq!(d.n_experts, sk::N_EXPERTS);
+        assert_eq!(d.top_k, sk::TOP_K);
+        assert_eq!(d.full_layers, sk::FULL_LAYERS);
+        assert_eq!(d.prefill_m(), sk::PREFILL_M);
+        assert_eq!(d.frozen_words(), sk::FROZEN_WORDS);
+        // The head-geometry literals in enc.rs and the pipeline shape list.
+        assert_eq!(d.q_cols(false), 4096);
+        assert_eq!(d.q_cols(true), 8192);
+        assert_eq!(d.kv_cols(false), 2048);
+        assert_eq!(d.kv_cols(true), 1024);
+        assert_eq!((d.head_dim(true), d.kv_heads(true)), (512, 2));
+        assert_eq!((d.head_dim(false), d.kv_heads(false)), (256, 8));
     }
 }

--- a/src/metal/step_config.rs
+++ b/src/metal/step_config.rs
@@ -38,6 +38,12 @@ pub struct ModelDims {
     /// Layer indices with full (global) attention; the rest slide.
     pub full_layers: Vec<usize>,
     pub rms_eps: f64,
+    pub rope_theta_sliding: f64,
+    pub rope_theta_full: f64,
+    /// Rotated dims per layer kind (sliding: the whole head; full: the
+    /// partial_rotary_factor slice of it).
+    pub rot_sliding: usize,
+    pub rot_full: usize,
     /// Causal sub-chunks batched into one prefill forward (see PREFILL_SUBS).
     pub prefill_subs: usize,
 }
@@ -63,6 +69,10 @@ impl ModelDims {
             full_head_dim: 512,
             full_layers: sk::FULL_LAYERS.to_vec(),
             rms_eps: 1e-6,
+            rope_theta_sliding: 1.0e4,
+            rope_theta_full: 1.0e6,
+            rot_sliding: 256,
+            rot_full: 128,
             prefill_subs: sk::PREFILL_SUBS,
         }
     }
@@ -85,6 +95,15 @@ impl ModelDims {
             full_head_dim: t.global_head_dim,
             full_layers: full_layers_from_config(&t.layer_types),
             rms_eps: t.rms_norm_eps,
+            rope_theta_sliding: t.rope_parameters.sliding_attention.rope_theta,
+            rope_theta_full: t.rope_parameters.full_attention.rope_theta,
+            rot_sliding: t.head_dim,
+            rot_full: ((t.global_head_dim as f64)
+                * t.rope_parameters
+                    .full_attention
+                    .partial_rotary_factor
+                    .unwrap_or(0.25))
+            .round() as usize,
             prefill_subs: crate::metal::step_kernel::PREFILL_SUBS,
         }
     }
@@ -155,7 +174,11 @@ impl ModelDims {
         for &l in &self.full_layers {
             eat(l as u64);
         }
+        eat(self.rot_sliding as u64);
+        eat(self.rot_full as u64);
         eat(self.rms_eps.to_bits());
+        eat(self.rope_theta_sliding.to_bits());
+        eat(self.rope_theta_full.to_bits());
         h
     }
 }

--- a/src/metal/step_generate/tests.rs
+++ b/src/metal/step_generate/tests.rs
@@ -299,14 +299,18 @@ fn begin_turn_after_abandoned_turn_prefills_the_new_prompt() {
 
 #[test]
 fn p21_denoise_readback_under_1mb() {
-    let bytes = StepRuntime::denoise_step_host_readback_bytes(false);
+    let bytes =
+        StepRuntime::denoise_step_host_readback_bytes(false, &crate::metal::ModelDims::reference());
     assert!(
         bytes <= 1024 * 1024,
         "hot-path readback {bytes} B exceeds 1 MiB"
     );
     assert_eq!(bytes, (StepRuntime::CANVAS_STATE_BYTES * 2) as u64);
     if logits_finite_check_enabled() {
-        let with_check = StepRuntime::denoise_step_host_readback_bytes(true);
+        let with_check = StepRuntime::denoise_step_host_readback_bytes(
+            true,
+            &crate::metal::ModelDims::reference(),
+        );
         assert!(with_check <= 1024 * 1024);
     }
 }

--- a/src/metal/step_generate/turn.rs
+++ b/src/metal/step_generate/turn.rs
@@ -579,7 +579,8 @@ pub fn propose_block(
             rt.check_logits_finite()?;
             let step_elapsed = step_started.elapsed();
             let step_ms = step_elapsed.as_secs_f64() * 1000.0;
-            let readback_bytes = StepRuntime::denoise_step_host_readback_bytes(check_logits);
+            let readback_bytes =
+                StepRuntime::denoise_step_host_readback_bytes(check_logits, rt.dims());
             let mut forward = ForwardTelemetry::monolithic_gpu_step(readback_bytes);
             rt.fill_expert_forward_telemetry(&mut forward);
             ts.session_telemetry.steps.push(StepPhaseTelemetry {

--- a/src/metal/step_kernel/build.rs
+++ b/src/metal/step_kernel/build.rs
@@ -119,7 +119,7 @@ pub fn build_step_runtime(
 
     let store = DgqStore::open(model_dir)?;
     let offsets = build_offsets_from_store(&store);
-    let layout = build_layout(&offsets, cfg.max_seq);
+    let layout = build_layout_with_dims(&offsets, cfg.max_seq, &validated.dims);
     if crate::flags::progress_enabled() {
         let fmt = crate::flags::kv_format(cfg.max_seq);
         if fmt != crate::shaders::kv_quant::KvFormat::F16 {
@@ -504,6 +504,7 @@ pub fn build_step_runtime(
         gpu_blob,
         weight_cache,
         text_config,
+        dims: validated.dims,
         block_profile,
         attn_format,
         dense_format,

--- a/src/metal/step_kernel/build.rs
+++ b/src/metal/step_kernel/build.rs
@@ -26,28 +26,33 @@ pub(super) fn prefill_bench_skipped(stage: step_schedule::StepStage) -> bool {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
-struct StepPipelineKey(u8);
+struct StepPipelineKey(u8, u64);
 
 fn step_pipeline_key(
     variant: crate::shaders::variant::KernelVariant,
     fmt: crate::shaders::kv_quant::KvFormat,
+    dims: &crate::metal::step_config::ModelDims,
 ) -> StepPipelineKey {
     // KV format code occupies bits 3-4 (0=f16, 1=q8, 2=q4); bit 5 = fp16 arena.
+    // The dims fingerprint keeps the process-global cache correct if two
+    // models with different geometry load in one process.
     StepPipelineKey(
         u8::from(variant.shape_assert)
             | (u8::from(variant.debug_fast) << 1)
             | (u8::from(variant.debug_deep) << 2)
             | ((fmt.code() as u8) << 3)
             | (u8::from(variant.arena_f16) << 5),
+        dims.fingerprint(),
     )
 }
 
 fn shared_step_pipelines(
     ctx: &MetalContext,
     fmt: crate::shaders::kv_quant::KvFormat,
+    dims: &crate::metal::step_config::ModelDims,
 ) -> Result<&'static StepPipelines, Error> {
     let variant = crate::shaders::variant::runtime_step_variant();
-    let key = step_pipeline_key(variant, fmt);
+    let key = step_pipeline_key(variant, fmt, dims);
     let cache = STEP_PIPELINES_CACHE.get_or_init(|| std::sync::Mutex::new(HashMap::new()));
     let mut guard = cache
         .lock()
@@ -56,19 +61,24 @@ fn shared_step_pipelines(
         return Ok(pipelines);
     }
 
-    let pipelines = StepPipelines::new(ctx, variant, fmt)?;
+    let pipelines = StepPipelines::new(ctx, variant, fmt, dims)?;
     let leaked: &'static StepPipelines = Box::leak(Box::new(pipelines));
     guard.insert(key, leaked);
     gpukit::metal::PipelineArchiveCache::flush_global();
     Ok(leaked)
 }
 
-pub fn log_step_memory_budget(blob_bytes: u64, max_seq: usize, layout: &ModelLayout) {
+pub fn log_step_memory_budget(
+    blob_bytes: u64,
+    max_seq: usize,
+    layout: &ModelLayout,
+    dims: &crate::metal::step_config::ModelDims,
+) {
     let kv = kv_cache_bytes(layout, max_seq);
-    let logits = (CANVAS * VOCAB * 2) as u64;
-    let sc_probs = sc_probs_buffer_bytes() as u64;
-    let arena = step_arena_layout().bytes();
-    let (mx, mw) = gemm_scratch_bytes();
+    let logits = (dims.canvas * dims.vocab * 2) as u64;
+    let sc_probs = sc_probs_buffer_bytes(dims) as u64;
+    let arena = step_arena_layout(dims).bytes();
+    let (mx, mw) = gemm_scratch_bytes(dims);
     let gemm_scratch = (mx + mw) as u64;
     let gpu_static = kv + logits + sc_probs + arena + gemm_scratch;
     let total = blob_bytes + gpu_static;
@@ -231,12 +241,12 @@ pub fn build_step_runtime(
     if f16_all {
         crate::shaders::variant::set_arena_f16_compile(true);
     }
-    let pipelines = shared_step_pipelines(&ctx, kv_fmt)?;
+    let pipelines = shared_step_pipelines(&ctx, kv_fmt, &validated.dims)?;
     // f16_all: LEAVE the compile-mode atomic on — lazy dispatch-time compiles
     // (stacked GEMM) must also build f16 for the whole session.
     let pipelines_prefill_f16 = if crate::flags::prefill_f16_enabled() {
         crate::shaders::variant::set_arena_f16_compile(true);
-        let out = shared_step_pipelines(&ctx, kv_fmt);
+        let out = shared_step_pipelines(&ctx, kv_fmt, &validated.dims);
         crate::shaders::variant::set_arena_f16_compile(false);
         Some(out?)
     } else {
@@ -248,9 +258,9 @@ pub fn build_step_runtime(
     let gpu_blob = std::sync::Arc::clone(&gpu_blob);
     let kv_bytes = kv_cache_bytes(&layout, cfg.max_seq) as usize;
     let logits_bytes = CANVAS * VOCAB * 2;
-    let sc_probs_bytes = sc_probs_buffer_bytes();
+    let sc_probs_bytes = sc_probs_buffer_bytes(&validated.dims);
 
-    log_step_memory_budget(store.blob_bytes(), cfg.max_seq, &layout);
+    log_step_memory_budget(store.blob_bytes(), cfg.max_seq, &layout, &validated.dims);
 
     let sampler = crate::sample::sampler_for_steps(cfg.steps.max(1), cfg.no_early_stop);
     let prefill_len = cfg
@@ -262,7 +272,7 @@ pub fn build_step_runtime(
     let eos_token_id = model_cfg.eos_token_id_u32();
     let params = step_params_from_sampler(&sampler, prefill_len, cfg.no_early_stop, eos_token_id);
     let state = init_canvas_state(cfg.seed, VOCAB);
-    let (gemm_a_bytes, gemm_b_bytes) = gemm_scratch_bytes();
+    let (gemm_a_bytes, gemm_b_bytes) = gemm_scratch_bytes(&validated.dims);
 
     let text_config = model_cfg.text_config;
     let weight_store = WeightStore::open(model_dir)?;
@@ -273,7 +283,7 @@ pub fn build_step_runtime(
         std::sync::Arc::clone(&gpu_blob),
     )?;
 
-    let arena_map = step_arena_layout();
+    let arena_map = step_arena_layout(&validated.dims);
     // KV cache: optionally file-backed (DGQ_KV_MMAP) so dirty pages evict to a
     // real file instead of anonymous swap. `kv_mmap_backing` must outlive
     // `kvcache` — it is declared after it in `StepBuffers` so it drops later.

--- a/src/metal/step_kernel/enc.rs
+++ b/src/metal/step_kernel/enc.rs
@@ -212,7 +212,7 @@ impl StepEnc<'_> {
 
     /// Softcap logits (matches ranged logit_softcapping dispatch pattern).
     pub(super) fn dispatch_softcap(&mut self) {
-        let len = CANVAS * VOCAB;
+        let len = self.dims.canvas * self.dims.vocab;
         self.dispatch_1d_ranged(&self.ps.softcap, len, 256, |this, base, chunk| {
             this.sink_set_buffer(&this.bufs.logits, 0, 0);
             this.sink_set_bytes(&base, 1);
@@ -676,10 +676,10 @@ impl StepEnc<'_> {
         self.sink_set_pipeline(&self.ps.logit_rowstats);
         self.bind_logits(0);
         self.sink_set_buffer(&self.bufs.arena, self.arena().rs_sc_off() as usize, 1);
-        let dims = [CANVAS as u32, VOCAB as u32];
+        let dims = [self.dims.canvas as u32, self.dims.vocab as u32];
         self.sink_set_bytes(&dims, 2);
         self.bind_debug_status(3);
-        let (grid, tg) = crate::shaders::logit_rowstats::dispatch_shape(CANVAS);
+        let (grid, tg) = crate::shaders::logit_rowstats::dispatch_shape(self.dims.canvas);
         self.sink_dispatch(grid, tg);
     }
 
@@ -695,10 +695,11 @@ impl StepEnc<'_> {
         self.bind_logits(0);
         self.sink_set_buffer(&self.bufs.arena, self.arena().rs_sc_off() as usize, 1);
         self.bind_sc_probs(2);
-        let params = [CANVAS as u32, VOCAB as u32, v0, chunk];
+        let params = [self.dims.canvas as u32, self.dims.vocab as u32, v0, chunk];
         self.sink_set_bytes(&params, 3);
         self.bind_debug_status(4);
-        let (grid, tg) = crate::shaders::sc_prob_cols::dispatch_shape(CANVAS, chunk as usize);
+        let (grid, tg) =
+            crate::shaders::sc_prob_cols::dispatch_shape(self.dims.canvas, chunk as usize);
         self.sink_dispatch(grid, tg);
     }
 
@@ -709,23 +710,23 @@ impl StepEnc<'_> {
         use crate::model::embed::LM_HEAD_CHUNK;
 
         // f32 accumulator in gemm_b (free during preamble, before layer GEMMs).
-        let acc_bytes = (CANVAS * HID * std::mem::size_of::<f32>()) as u64;
+        let acc_bytes = (self.dims.canvas * self.dims.hid * std::mem::size_of::<f32>()) as u64;
         self.memzero_buffer(&self.bufs.gemm_b, acc_bytes);
         self.sink_memory_barrier(); // memzero gemm_b before the first `+=`
 
-        let row_bytes = q8_row_bytes(HID) as u64;
+        let row_bytes = q8_row_bytes(self.dims.hid) as u64;
         let chunk_max = LM_HEAD_CHUNK as u32;
         let mut v0 = 0u32;
-        while v0 < VOCAB as u32 {
-            let chunk = (VOCAB as u32 - v0).min(chunk_max);
+        while v0 < self.dims.vocab as u32 {
+            let chunk = (self.dims.vocab as u32 - v0).min(chunk_max);
             self.dispatch_sc_prob_cols(v0, chunk);
             if self.embed_bf16 {
-                let w_off = layout.embed + (v0 as u64) * (HID as u64) * 2;
+                let w_off = layout.embed + (v0 as u64) * (self.dims.hid as u64) * 2;
                 self.gemm_bf16_rowk_acc_f32(
                     &self.bufs.gemm_b,
                     w_off,
-                    CANVAS as u32,
-                    HID as u32,
+                    self.dims.canvas as u32,
+                    self.dims.hid as u32,
                     chunk,
                 )?;
             } else {
@@ -733,8 +734,8 @@ impl StepEnc<'_> {
                 self.gemm_q8_rowk_acc_f32(
                     &self.bufs.gemm_b,
                     w_off,
-                    CANVAS as u32,
-                    HID as u32,
+                    self.dims.canvas as u32,
+                    self.dims.hid as u32,
                     chunk,
                 )?;
             }
@@ -744,11 +745,11 @@ impl StepEnc<'_> {
         // Convert f32 accumulator → bf16 arena soft slot, applying embed_scale
         // (== sqrt(HID)) and dividing out the SC_PROB_GEMM_SCALE that sc_prob_cols
         // multiplied into the probs to keep them in fp16's normal range.
-        let scale = (HID as f32).sqrt() / SC_PROB_GEMM_SCALE;
+        let scale = (self.dims.hid as f32).sqrt() / SC_PROB_GEMM_SCALE;
         self.f32_to_half_scale(
             &self.bufs.gemm_b,
             self.arena().soft_off(),
-            CANVAS * HID,
+            self.dims.canvas * self.dims.hid,
             scale,
         );
         Ok(())
@@ -774,11 +775,11 @@ impl StepEnc<'_> {
         self.sink_set_buffer(&self.bufs.gemm_b, IDX_OFF, 2);
         self.sink_set_buffer(&self.bufs.gemm_a, PROB_OFF, 3);
         self.sink_set_buffer(&self.bufs.gemm_a, CNT_OFF, 4);
-        let p1 = [CANVAS as u32, VOCAB as u32, maxk, 0u32];
+        let p1 = [self.dims.canvas as u32, self.dims.vocab as u32, maxk, 0u32];
         self.sink_set_bytes(&p1, 5);
         self.sink_dispatch(
             MTLSize {
-                width: CANVAS,
+                width: self.dims.canvas,
                 height: 1,
                 depth: 1,
             },
@@ -798,11 +799,11 @@ impl StepEnc<'_> {
         self.bind_blob(3);
         self.sink_set_bytes(&layout.embed, 4);
         self.sink_set_buffer(&self.bufs.gemm_b, 0, 5);
-        let p2 = [CANVAS as u32, HID as u32, maxk, 0u32];
+        let p2 = [self.dims.canvas as u32, self.dims.hid as u32, maxk, 0u32];
         self.sink_set_bytes(&p2, 6);
         self.sink_dispatch(
             MTLSize {
-                width: CANVAS,
+                width: self.dims.canvas,
                 height: 1,
                 depth: 1,
             },
@@ -815,11 +816,11 @@ impl StepEnc<'_> {
         self.sink_memory_barrier();
 
         // Finalize: f32 accumulator → bf16 soft slot (÷ SC_PROB_GEMM_SCALE, × √HID).
-        let scale = (HID as f32).sqrt() / SC_PROB_GEMM_SCALE;
+        let scale = (self.dims.hid as f32).sqrt() / SC_PROB_GEMM_SCALE;
         self.f32_to_half_scale(
             &self.bufs.gemm_b,
             self.arena().soft_off(),
-            CANVAS * HID,
+            self.dims.canvas * self.dims.hid,
             scale,
         );
         Ok(())
@@ -883,7 +884,7 @@ impl StepEnc<'_> {
             self.arena().tmp_off(),
             l.o_proj,
             fm as u32,
-            HID as u32,
+            self.dims.hid as u32,
             o_k,
         )
     }
@@ -899,7 +900,7 @@ impl StepEnc<'_> {
             self.arena().tmp_off(),
             self.arena().tmp_off(),
             l.post_attn_ln,
-            HID as u32,
+            self.dims.hid as u32,
             fm,
         );
         self.residual(
@@ -907,7 +908,7 @@ impl StepEnc<'_> {
             self.arena().tmp_off(),
             self.arena().stream_off(),
             0,
-            fm * HID,
+            fm * self.dims.hid,
         );
         Ok(())
     }
@@ -923,7 +924,7 @@ impl StepEnc<'_> {
             self.arena().stream_off(),
             self.arena().tmp_off(),
             l.pre_ff_ln,
-            HID as u32,
+            self.dims.hid as u32,
             fm,
         );
         self.encode_layer_dense_gate_up(layer, layout)?;
@@ -931,14 +932,14 @@ impl StepEnc<'_> {
             self.arena().ffg_off(),
             self.arena().ffu_off(),
             self.arena().ffg_off(),
-            fm * DENSE_FF as usize,
+            fm * self.dims.dense_ff,
         );
         self.encode_layer_dense_down(layer, layout)?;
         self.rmsnorm(
             self.arena().dense_off(),
             self.arena().dense_off(),
             l.post_ff_ln_1,
-            HID as u32,
+            self.dims.hid as u32,
             fm,
         );
         Ok(())
@@ -957,8 +958,8 @@ impl StepEnc<'_> {
             self.arena().dense_off(),
             l.mlp_down,
             fm as u32,
-            HID as u32,
-            DENSE_FF,
+            self.dims.hid as u32,
+            self.dims.dense_ff as u32,
         )
     }
 
@@ -970,24 +971,26 @@ impl StepEnc<'_> {
         let fm = self.forward_m;
         let l = &layout.layers[layer];
         if fused_gate_up_enabled() && self.dense_format.is_bf16() {
-            let (segs, n_total) = gate_up_stacked_segments(l, self.arena());
+            let (segs, n_total) =
+                gate_up_stacked_segments(l, self.arena(), self.dims.dense_ff as u32);
             self.gemm_bf16_stacked(
                 self.arena().tmp_off(),
                 &segs,
                 fm as u32,
-                HID as u32,
+                self.dims.hid as u32,
                 n_total,
             )?;
         } else if fused_gate_up_enabled()
             && let Some(fmt) = self.dense_format.block_format()
         {
-            let (segs, n_total) = gate_up_stacked_segments(l, self.arena());
+            let (segs, n_total) =
+                gate_up_stacked_segments(l, self.arena(), self.dims.dense_ff as u32);
             self.gemm_q4_stacked(
                 fmt,
                 self.arena().tmp_off(),
                 &segs,
                 fm as u32,
-                HID as u32,
+                self.dims.hid as u32,
                 n_total,
             )?;
         } else {
@@ -997,8 +1000,8 @@ impl StepEnc<'_> {
                 self.arena().ffg_off(),
                 l.mlp_gate,
                 fm as u32,
-                DENSE_FF,
-                HID as u32,
+                self.dims.dense_ff as u32,
+                self.dims.hid as u32,
             )?;
             self.gemm_dense_linear(
                 self.dense_format,
@@ -1006,8 +1009,8 @@ impl StepEnc<'_> {
                 self.arena().ffu_off(),
                 l.mlp_up,
                 fm as u32,
-                DENSE_FF,
-                HID as u32,
+                self.dims.dense_ff as u32,
+                self.dims.hid as u32,
             )?;
         }
         Ok(())
@@ -1022,10 +1025,10 @@ impl StepEnc<'_> {
         let layer_off = layer_byte_offset(layer);
         let router_dims = crate::shaders::moe_router::RouterDims {
             canvas: fm as u32,
-            hidden: HID as u32,
-            n_experts: N_EXPERTS as u32,
-            top_k: TOP_K as u32,
-            router_hscale: (HID as f32).powf(-0.5),
+            hidden: self.dims.hid as u32,
+            n_experts: self.dims.n_experts as u32,
+            top_k: self.dims.top_k as u32,
+            router_hscale: (self.dims.hid as f32).powf(-0.5),
             block_m: self.moe_block_m(),
         };
         if router_gemm_enabled() {
@@ -1040,7 +1043,7 @@ impl StepEnc<'_> {
                 self.arena().stream_off(),
                 self.arena().tmp_off(),
                 l.router_scale,
-                HID as u32,
+                self.dims.hid as u32,
                 fm,
             );
             self.gemm_bf16(
@@ -1048,8 +1051,8 @@ impl StepEnc<'_> {
                 self.arena().ffg_off(),
                 l.router_proj,
                 fm as u32,
-                N_EXPERTS as u32,
-                HID as u32,
+                self.dims.n_experts as u32,
+                self.dims.hid as u32,
             )?;
             self.sink_set_pipeline(&self.ps.router_topk);
             self.sink_set_buffer(&self.bufs.arena, self.arena().ffg_off() as usize, 0);
@@ -1092,7 +1095,7 @@ impl StepEnc<'_> {
 
         self.sink_set_pipeline(&self.ps.bucket_count);
         self.bind_route(0);
-        let n_experts = N_EXPERTS as u32;
+        let n_experts = self.dims.n_experts as u32;
         self.sink_set_bytes(&n_experts, 1);
         self.dispatch_1d(&self.ps.bucket_count, 128, 128);
 
@@ -1108,7 +1111,7 @@ impl StepEnc<'_> {
             self.sink_set_buffer(&self.bufs.moe_grouped_indirect, 0, 6);
             let grid_info = moe_grouped_grid_info();
             self.sink_set_bytes(&grid_info, 7);
-            let count = if phase == 1 { 1 } else { fm * TOP_K };
+            let count = if phase == 1 { 1 } else { fm * self.dims.top_k };
             self.dispatch_1d(&self.ps.bucket_fill, count, 256);
         }
 
@@ -1117,10 +1120,10 @@ impl StepEnc<'_> {
             self.arena().stream_off(),
             self.arena().moein_off(),
             l.pre_ff_ln_2,
-            HID as u32,
+            self.dims.hid as u32,
             fm,
         );
-        self.memzero_bytes(self.arena().moeout_off(), (fm * HID * 4) as u64);
+        self.memzero_bytes(self.arena().moeout_off(), (fm * self.dims.hid * 4) as u64);
         Ok(())
     }
 
@@ -1131,7 +1134,7 @@ impl StepEnc<'_> {
     /// so dispatch_block_linear_grouped MUST select the matching pipeline —
     /// both read this one function.
     fn moe_block_m(&self) -> u32 {
-        if self.forward_m <= CANVAS {
+        if self.forward_m <= self.dims.canvas {
             return 32;
         }
         let fmt = self.block_profile.format;
@@ -1140,11 +1143,16 @@ impl StepEnc<'_> {
         // is only built for the block-expert formats q4/q6/nvfp4).
         let wide_ok = self
             .ps
-            .sparse_tunable_wide_fmt(fmt, MOE_FF * 2, HID as u32, false)
+            .sparse_tunable_wide_fmt(
+                fmt,
+                self.dims.moe_ff as u32 * 2,
+                self.dims.hid as u32,
+                false,
+            )
             .is_some()
             && self
                 .ps
-                .sparse_tunable_wide_fmt(fmt, HID as u32, MOE_FF, false)
+                .sparse_tunable_wide_fmt(fmt, self.dims.hid as u32, self.dims.moe_ff as u32, false)
                 .is_some();
         if wide_ok {
             if crate::flags::progress_enabled() {
@@ -1225,7 +1233,7 @@ impl StepEnc<'_> {
         self.sink_set_buffer(&self.bufs.gemm_b, buf_c_off, 2);
         self.sink_set_bytes(jobs, 3);
         self.sink_set_buffer(&self.bufs.route, row_start_off, 4);
-        let num_jobs = N_EXPERTS as u32;
+        let num_jobs = self.dims.n_experts as u32;
         self.sink_set_bytes(&num_jobs, 5);
         self.bind_route(6);
         if use_gather {
@@ -1265,9 +1273,9 @@ impl StepEnc<'_> {
 
     pub(super) fn encode_moe_batched_gather_bf16_to_f32(&mut self) -> Result<(), Error> {
         let token_list_off = std::mem::offset_of!(RouteScratch, token_list);
-        let gather_dims = [0u32, HID as u32];
-        let slots = (self.forward_m * TOP_K) as u32;
-        let gather_count = slots as usize * HID;
+        let gather_dims = [0u32, self.dims.hid as u32];
+        let slots = (self.forward_m * self.dims.top_k) as u32;
+        let gather_count = slots as usize * self.dims.hid;
         self.dispatch_1d_ranged(
             &self.ps.gather_rows_bf16_to_f32,
             gather_count,
@@ -1294,6 +1302,7 @@ impl StepEnc<'_> {
         let (gate_jobs, _) = layer_moe_block_jobs_impl(
             l,
             self.block_profile.format,
+            self.dims,
             Some((layer, self.tensor_offsets)),
             self.bufs.blob_expert_base,
         );
@@ -1303,8 +1312,8 @@ impl StepEnc<'_> {
             moe_w_byte_off_gu(),
             &gate_jobs,
             MOE_SLOTS,
-            HID as u32,
-            MOE_FF * 2,
+            self.dims.hid as u32,
+            self.dims.moe_ff as u32 * 2,
             0,
             moe_fuse_gather_enabled(),
         )
@@ -1312,13 +1321,13 @@ impl StepEnc<'_> {
 
     pub(super) fn encode_moe_batched_swiglu(&mut self) -> Result<(), Error> {
         let gu_off = moe_w_byte_off_gu();
-        let slots = (self.forward_m * TOP_K) as u32;
-        let act_elems = slots as usize * MOE_FF as usize;
+        let slots = (self.forward_m * self.dims.top_k) as u32;
+        let act_elems = slots as usize * self.dims.moe_ff;
         self.sink_set_pipeline(&self.ps.gelu_swiglu_gate_up);
         self.sink_set_buffer(&self.bufs.gemm_b, gu_off, 0);
         self.sink_set_buffer(&self.bufs.gemm_a, 0, 1);
         self.sink_set_buffer(&self.bufs.dummy_dump, 0, 3);
-        let swiglu_dims = [slots, MOE_FF];
+        let swiglu_dims = [slots, self.dims.moe_ff as u32];
         self.sink_set_bytes(&swiglu_dims, 2);
         self.dispatch_1d(&self.ps.gelu_swiglu_gate_up, act_elems, 256);
         Ok(())
@@ -1333,6 +1342,7 @@ impl StepEnc<'_> {
         let (_, down_jobs) = layer_moe_block_jobs_impl(
             l,
             self.block_profile.format,
+            self.dims,
             None,
             self.bufs.blob_expert_base,
         );
@@ -1342,8 +1352,8 @@ impl StepEnc<'_> {
             moe_w_byte_off_a(),
             &down_jobs,
             MOE_SLOTS,
-            MOE_FF,
-            HID as u32,
+            self.dims.moe_ff as u32,
+            self.dims.hid as u32,
             1,
             false,
         )
@@ -1355,7 +1365,7 @@ impl StepEnc<'_> {
         self.sink_set_buffer(&self.bufs.gemm_b, moe_w_byte_off_a(), 0);
         self.sink_set_buffer(&self.bufs.arena, self.arena().moeout_off() as usize, 1);
         self.bind_route(2);
-        let hidden = HID as u32;
+        let hidden = self.dims.hid as u32;
         let canvas = fm as u32;
         self.sink_set_bytes(&hidden, 3);
         self.sink_set_bytes(&canvas, 4);
@@ -1389,9 +1399,9 @@ impl StepEnc<'_> {
         self.bind_route(4);
         let grouped_dims = crate::shaders::moe_grouped::GroupedDims {
             canvas: fm as u32,
-            hidden: HID as u32,
-            moe_ff: MOE_FF,
-            n_experts: N_EXPERTS as u32,
+            hidden: self.dims.hid as u32,
+            moe_ff: self.dims.moe_ff as u32,
+            n_experts: self.dims.n_experts as u32,
         };
         self.sink_set_bytes(&grouped_dims, 5);
         if !self.block_profile.is_nvfp4() {
@@ -1399,7 +1409,7 @@ impl StepEnc<'_> {
         }
         let grid = MTLSize {
             width: fm,
-            height: N_EXPERTS,
+            height: self.dims.n_experts,
             depth: 1,
         };
         let tg = MTLSize {
@@ -1433,7 +1443,7 @@ impl StepEnc<'_> {
             self.arena().moeout_off(),
             self.arena().moein_off(),
             l.post_ff_ln_2,
-            HID as u32,
+            self.dims.hid as u32,
             fm,
         );
         Ok(())
@@ -1451,13 +1461,13 @@ impl StepEnc<'_> {
             self.arena().moein_off(),
             self.arena().tmp_off(),
             0,
-            fm * HID,
+            fm * self.dims.hid,
         );
         self.rmsnorm(
             self.arena().tmp_off(),
             self.arena().tmp_off(),
             l.post_ff_ln,
-            HID as u32,
+            self.dims.hid as u32,
             fm,
         );
         self.residual(
@@ -1465,7 +1475,7 @@ impl StepEnc<'_> {
             self.arena().tmp_off(),
             self.arena().hidden_off(),
             l.layer_scalar,
-            fm * HID,
+            fm * self.dims.hid,
         );
         Ok(())
     }
@@ -1505,10 +1515,13 @@ impl StepEnc<'_> {
             self.arena().stream_off(),
             self.arena().moein_off(),
             l.pre_ff_ln_2,
-            HID as u32,
-            CANVAS,
+            self.dims.hid as u32,
+            self.dims.canvas,
         );
-        self.memzero_bytes(self.arena().moeout_off(), (CANVAS * HID * 4) as u64);
+        self.memzero_bytes(
+            self.arena().moeout_off(),
+            (self.dims.canvas * self.dims.hid * 4) as u64,
+        );
         write_single_expert_route(&self.bufs.route, position, expert_id);
     }
 
@@ -1524,7 +1537,10 @@ impl StepEnc<'_> {
             ));
         }
         let layer_off = layer_byte_offset(layer);
-        self.memzero_bytes(self.arena().moeout_off(), (CANVAS * HID * 4) as u64);
+        self.memzero_bytes(
+            self.arena().moeout_off(),
+            (self.dims.canvas * self.dims.hid * 4) as u64,
+        );
         self.memzero_bytes(
             self.arena().soft_off(),
             (MOE_ACT_PROBE_FLOATS * std::mem::size_of::<f32>()) as u64,
@@ -1537,15 +1553,15 @@ impl StepEnc<'_> {
         self.bind_route(4);
         self.sink_set_buffer(&self.bufs.arena, self.arena().soft_off() as usize, 6);
         let grouped_dims = crate::shaders::moe_grouped::GroupedDims {
-            canvas: CANVAS as u32,
-            hidden: HID as u32,
-            moe_ff: MOE_FF,
-            n_experts: N_EXPERTS as u32,
+            canvas: self.dims.canvas as u32,
+            hidden: self.dims.hid as u32,
+            moe_ff: self.dims.moe_ff as u32,
+            n_experts: self.dims.n_experts as u32,
         };
         self.sink_set_bytes(&grouped_dims, 5);
         let grid = MTLSize {
-            width: CANVAS,
-            height: N_EXPERTS,
+            width: self.dims.canvas,
+            height: self.dims.n_experts,
             depth: 1,
         };
         let tg = MTLSize {
@@ -1569,7 +1585,7 @@ impl StepEnc<'_> {
             self.arena().hidden_off(),
             self.arena().tmp_off(),
             l.input_ln,
-            HID as u32,
+            self.dims.hid as u32,
             fm,
         );
         if fused_qkv_enabled() && self.attn_format.is_bf16() {
@@ -1578,7 +1594,7 @@ impl StepEnc<'_> {
                 self.arena().tmp_off(),
                 &segs,
                 fm as u32,
-                HID as u32,
+                self.dims.hid as u32,
                 n_total,
             )?;
         } else if fused_qkv_enabled()
@@ -1590,7 +1606,7 @@ impl StepEnc<'_> {
                 self.arena().tmp_off(),
                 &segs,
                 fm as u32,
-                HID as u32,
+                self.dims.hid as u32,
                 n_total,
             )?;
         } else {
@@ -1603,7 +1619,7 @@ impl StepEnc<'_> {
                 l.q_proj,
                 fm as u32,
                 q_n,
-                HID as u32,
+                self.dims.hid as u32,
             )?;
             self.gemm_dense_linear(
                 self.attn_format,
@@ -1612,7 +1628,7 @@ impl StepEnc<'_> {
                 l.k_proj,
                 fm as u32,
                 k_n,
-                HID as u32,
+                self.dims.hid as u32,
             )?;
             if l.v_proj != 0 {
                 self.gemm_dense_linear(
@@ -1622,7 +1638,7 @@ impl StepEnc<'_> {
                     l.v_proj,
                     fm as u32,
                     k_n,
-                    HID as u32,
+                    self.dims.hid as u32,
                 )?;
             }
         }
@@ -1646,8 +1662,8 @@ impl StepEnc<'_> {
                 fmt,
                 self.arena().tmp_off(),
                 &segs,
-                CANVAS as u32,
-                HID as u32,
+                self.dims.canvas as u32,
+                self.dims.hid as u32,
                 n_total,
             )?;
         } else {
@@ -1658,18 +1674,18 @@ impl StepEnc<'_> {
                 self.arena().tmp_off(),
                 self.arena().attnq_off(),
                 l.q_proj,
-                CANVAS as u32,
+                self.dims.canvas as u32,
                 q_n,
-                HID as u32,
+                self.dims.hid as u32,
             )?;
             self.gemm_dense_linear(
                 self.attn_format,
                 self.arena().tmp_off(),
                 self.arena().attnk_off(),
                 l.k_proj,
-                CANVAS as u32,
+                self.dims.canvas as u32,
                 k_n,
-                HID as u32,
+                self.dims.hid as u32,
             )?;
             if l.v_proj != 0 {
                 self.gemm_dense_linear(
@@ -1677,9 +1693,9 @@ impl StepEnc<'_> {
                     self.arena().tmp_off(),
                     self.arena().attnv_off(),
                     l.v_proj,
-                    CANVAS as u32,
+                    self.dims.canvas as u32,
                     k_n,
-                    HID as u32,
+                    self.dims.hid as u32,
                 )?;
             }
         }
@@ -1698,13 +1714,14 @@ impl StepEnc<'_> {
             let fmt = self.dense_format.block_format().ok_or(Error::Format(
                 "dispatch_gate_up_gemms: stacked requires a block dense format",
             ))?;
-            let (segs, n_total) = gate_up_stacked_segments(l, self.arena());
+            let (segs, n_total) =
+                gate_up_stacked_segments(l, self.arena(), self.dims.dense_ff as u32);
             self.gemm_q4_stacked(
                 fmt,
                 self.arena().tmp_off(),
                 &segs,
-                CANVAS as u32,
-                HID as u32,
+                self.dims.canvas as u32,
+                self.dims.hid as u32,
                 n_total,
             )?;
         } else {
@@ -1713,18 +1730,18 @@ impl StepEnc<'_> {
                 self.arena().tmp_off(),
                 self.arena().ffg_off(),
                 l.mlp_gate,
-                CANVAS as u32,
-                DENSE_FF,
-                HID as u32,
+                self.dims.canvas as u32,
+                self.dims.dense_ff as u32,
+                self.dims.hid as u32,
             )?;
             self.gemm_dense_linear(
                 self.dense_format,
                 self.arena().tmp_off(),
                 self.arena().ffu_off(),
                 l.mlp_up,
-                CANVAS as u32,
-                DENSE_FF,
-                HID as u32,
+                self.dims.canvas as u32,
+                self.dims.dense_ff as u32,
+                self.dims.hid as u32,
             )?;
         }
         Ok(())
@@ -1756,8 +1773,8 @@ impl StepEnc<'_> {
         // Per-sub-chunk row offsets into the batched Q/K/V planes (sub_c = 0
         // outside a super-chunk). K/V planes are written at the layer's native
         // widths (n_kv*hd); Q at n_q*hd.
-        let q_row = CANVAS * self.sub_c * STEP_NQ_HEADS * l.head_dim as usize * 2;
-        let kv_row = CANVAS * self.sub_c * (l.n_kv_heads * l.head_dim) as usize * 2;
+        let q_row = self.dims.canvas * self.sub_c * STEP_NQ_HEADS * l.head_dim as usize * 2;
+        let kv_row = self.dims.canvas * self.sub_c * (l.n_kv_heads * l.head_dim) as usize * 2;
         self.sink_set_buffer(
             &self.bufs.arena,
             self.arena().attnq_off() as usize + q_row,
@@ -1846,7 +1863,7 @@ impl StepEnc<'_> {
         let t_total = kv_len + m;
         let np = n_pad(t_total);
         // Q/O sub-chunk row offset into the batched prefill planes.
-        let qo_row = CANVAS * self.sub_c * STEP_NQ_HEADS * hd * 2;
+        let qo_row = self.dims.canvas * self.sub_c * STEP_NQ_HEADS * hd * 2;
         // Tunable tile geometry — must match the compiled GEMM
         // pipelines. The top-k tiles are compile-time consts.
         let (qk_bm_f, qk_bn_f, pv_bm_f, pv_bn_f, sm_tpg) = crate::flags::gemm_attn_tile();
@@ -2050,7 +2067,7 @@ impl StepEnc<'_> {
         let m = self.active_canvas;
         let kv_len = self.dispatch_kv_len() as usize;
         let t_total = kv_len + m;
-        let qo_row = CANVAS * self.sub_c * STEP_NQ_HEADS * hd * 2;
+        let qo_row = self.dims.canvas * self.sub_c * STEP_NQ_HEADS * hd * 2;
         let window = if attn_window_enabled() {
             self.sliding_window
         } else {
@@ -2177,7 +2194,7 @@ impl StepEnc<'_> {
         }
         // Per-sub-chunk row offsets into the batched Q/O planes (sub_c = 0
         // outside a super-chunk).
-        let qo_row = CANVAS * self.sub_c * STEP_NQ_HEADS * l.head_dim as usize * 2;
+        let qo_row = self.dims.canvas * self.sub_c * STEP_NQ_HEADS * l.head_dim as usize * 2;
         self.sink_set_buffer(
             &self.bufs.arena,
             self.arena().attnq_off() as usize + qo_row,
@@ -2326,8 +2343,8 @@ impl StepEnc<'_> {
                     self.arena().soft_off(),
                     self.arena().tmp_off(),
                     layout.sc_pre_norm,
-                    HID as u32,
-                    CANVAS,
+                    self.dims.hid as u32,
+                    self.dims.canvas,
                 );
                 Ok(())
             }
@@ -2336,25 +2353,25 @@ impl StepEnc<'_> {
                 self.arena().tmp_off(),
                 self.arena().ffg_off(),
                 layout.sc_gate,
-                CANVAS as u32,
-                DENSE_FF,
-                HID as u32,
+                self.dims.canvas as u32,
+                self.dims.dense_ff as u32,
+                self.dims.hid as u32,
             ),
             StepStage::ScUpGemm => self.gemm_dense_linear(
                 self.sc_format,
                 self.arena().tmp_off(),
                 self.arena().ffu_off(),
                 layout.sc_up,
-                CANVAS as u32,
-                DENSE_FF,
-                HID as u32,
+                self.dims.canvas as u32,
+                self.dims.dense_ff as u32,
+                self.dims.hid as u32,
             ),
             StepStage::ScGlu => {
                 self.glu(
                     self.arena().ffg_off(),
                     self.arena().ffu_off(),
                     self.arena().ffg_off(),
-                    CANVAS * DENSE_FF as usize,
+                    self.dims.canvas * self.dims.dense_ff,
                 );
                 Ok(())
             }
@@ -2363,9 +2380,9 @@ impl StepEnc<'_> {
                 self.arena().ffg_off(),
                 self.arena().dense_off(),
                 layout.sc_down,
-                CANVAS as u32,
-                HID as u32,
-                DENSE_FF,
+                self.dims.canvas as u32,
+                self.dims.hid as u32,
+                self.dims.dense_ff as u32,
             ),
             StepStage::EmbedGather => {
                 self.dispatch_embed_gather(layout.embed);
@@ -2377,7 +2394,7 @@ impl StepEnc<'_> {
                     self.arena().dense_off(),
                     self.arena().hidden_off(),
                     0,
-                    CANVAS * HID,
+                    self.dims.canvas * self.dims.hid,
                 );
                 Ok(())
             }
@@ -2386,7 +2403,7 @@ impl StepEnc<'_> {
                     self.arena().hidden_off(),
                     self.arena().hidden_off(),
                     0,
-                    HID as u32,
+                    self.dims.hid as u32,
                     self.forward_m,
                 );
                 Ok(())
@@ -2417,8 +2434,8 @@ impl StepEnc<'_> {
                     self.arena().hidden_off(),
                     self.arena().tmp_off(),
                     layout.final_norm,
-                    HID as u32,
-                    CANVAS,
+                    self.dims.hid as u32,
+                    self.dims.canvas,
                 );
                 Ok(())
             }
@@ -2430,20 +2447,20 @@ impl StepEnc<'_> {
                     self.gemm_bf16_logits(
                         self.arena().tmp_off(),
                         layout.embed,
-                        CANVAS as u32,
-                        VOCAB as u32,
-                        HID as u32,
+                        self.dims.canvas as u32,
+                        self.dims.vocab as u32,
+                        self.dims.hid as u32,
                         0,
                     )
-                } else if partial_lm_head_enabled() && m < CANVAS as u32 {
+                } else if partial_lm_head_enabled() && m < self.dims.canvas as u32 {
                     self.encode_partial_lm_head(layout, m)
                 } else {
                     self.gemm_q8_logits(
                         self.arena().tmp_off(),
                         layout.embed,
-                        CANVAS as u32,
-                        VOCAB as u32,
-                        HID as u32,
+                        self.dims.canvas as u32,
+                        self.dims.vocab as u32,
+                        self.dims.hid as u32,
                         0,
                     )
                 }
@@ -2499,8 +2516,8 @@ impl StepEnc<'_> {
                 self.arena().hidden_off(),
                 self.arena().tmp_off(),
                 layout.sc_pre_norm,
-                HID as u32,
-                CANVAS,
+                self.dims.hid as u32,
+                self.dims.canvas,
             );
             self.exec_stage(StepStage::ScGateGemm, 0, layout, finish)?;
             self.exec_stage(StepStage::ScUpGemm, 0, layout, finish)?;
@@ -2591,7 +2608,7 @@ impl StepEnc<'_> {
     ) -> Result<(), Error> {
         use step_schedule::StepStage;
         self.prefill_causal = true;
-        self.forward_m = n_subs * CANVAS;
+        self.forward_m = n_subs * self.dims.canvas;
         self.exec_stage(
             StepStage::EmbedGather,
             0,
@@ -2634,7 +2651,7 @@ impl StepEnc<'_> {
                 }
             }
         }
-        self.forward_m = CANVAS;
+        self.forward_m = self.dims.canvas;
         Ok(())
     }
 
@@ -2662,13 +2679,13 @@ impl StepEnc<'_> {
         self.bind_state(1);
         self.sink_set_buffer(&self.bufs.arena, self.arena().hidden_off() as usize, 2);
         self.sink_set_bytes(&embed_off, 3);
-        let dims = [HID as u32, fm as u32];
+        let dims = [self.dims.hid as u32, fm as u32];
         self.sink_set_bytes(&dims, 4);
         self.sink_set_bytes(&EMBED_SCALE, 5);
-        let vocab = VOCAB as u32;
+        let vocab = self.dims.vocab as u32;
         self.sink_set_bytes(&vocab, 6);
         self.bind_debug_status(7);
-        let (grid, tg) = crate::shaders::embed_gather::dispatch_shape(HID, fm);
+        let (grid, tg) = crate::shaders::embed_gather::dispatch_shape(self.dims.hid, fm);
         self.sink_dispatch(grid, tg);
     }
 
@@ -2691,41 +2708,41 @@ impl StepEnc<'_> {
                 self.arena().soft_off(),
                 self.arena().tmp_off(),
                 layout.sc_pre_norm,
-                HID as u32,
-                CANVAS,
+                self.dims.hid as u32,
+                self.dims.canvas,
             );
             self.gemm_dense_linear(
                 self.sc_format,
                 self.arena().tmp_off(),
                 self.arena().ffg_off(),
                 layout.sc_gate,
-                CANVAS as u32,
-                DENSE_FF,
-                HID as u32,
+                self.dims.canvas as u32,
+                self.dims.dense_ff as u32,
+                self.dims.hid as u32,
             )?;
             self.gemm_dense_linear(
                 self.sc_format,
                 self.arena().tmp_off(),
                 self.arena().ffu_off(),
                 layout.sc_up,
-                CANVAS as u32,
-                DENSE_FF,
-                HID as u32,
+                self.dims.canvas as u32,
+                self.dims.dense_ff as u32,
+                self.dims.hid as u32,
             )?;
             self.glu(
                 self.arena().ffg_off(),
                 self.arena().ffu_off(),
                 self.arena().ffg_off(),
-                CANVAS * DENSE_FF as usize,
+                self.dims.canvas * self.dims.dense_ff,
             );
             self.gemm_dense_linear(
                 self.sc_format,
                 self.arena().ffg_off(),
                 self.arena().dense_off(),
                 layout.sc_down,
-                CANVAS as u32,
-                HID as u32,
-                DENSE_FF,
+                self.dims.canvas as u32,
+                self.dims.hid as u32,
+                self.dims.dense_ff as u32,
             )?;
         }
         // first_step: self.arena().dense_off() stays zero; skip SC MLP + O(vocab) softembed.
@@ -2736,14 +2753,14 @@ impl StepEnc<'_> {
             self.arena().dense_off(),
             self.arena().hidden_off(),
             0,
-            CANVAS * HID,
+            self.dims.canvas * self.dims.hid,
         );
         self.rmsnorm(
             self.arena().hidden_off(),
             self.arena().hidden_off(),
             0,
-            HID as u32,
-            CANVAS,
+            self.dims.hid as u32,
+            self.dims.canvas,
         );
         Ok(())
     }
@@ -2751,8 +2768,8 @@ impl StepEnc<'_> {
     fn encode_partial_lm_head(&mut self, layout: &ModelLayout, m: u32) -> Result<(), Error> {
         let token_list_off = std::mem::offset_of!(RouteScratch, token_list);
         let num_slots_off = std::mem::offset_of!(RouteScratch, num_slots);
-        let compact_row = CANVAS as u32 - m;
-        let logits_off = (compact_row as usize) * VOCAB * 2;
+        let compact_row = self.dims.canvas as u32 - m;
+        let logits_off = (compact_row as usize) * self.dims.vocab * 2;
 
         self.sink_set_pipeline(&self.ps.compact_active_rows);
         self.bind_state(0);
@@ -2770,8 +2787,8 @@ impl StepEnc<'_> {
         };
         self.sink_dispatch(grid, tg);
 
-        let gather_dims = [0u32, HID as u32];
-        let gather_count = (m as usize) * HID;
+        let gather_dims = [0u32, self.dims.hid as u32];
+        let gather_count = (m as usize) * self.dims.hid;
         self.dispatch_1d_ranged(
             &self.ps.gather_rows_bf16,
             gather_count,
@@ -2791,19 +2808,19 @@ impl StepEnc<'_> {
             self.arena().dense_off(),
             layout.embed,
             m,
-            VOCAB as u32,
-            HID as u32,
+            self.dims.vocab as u32,
+            self.dims.hid as u32,
             logits_off,
         )?;
 
-        let dims = [m, VOCAB as u32];
+        let dims = [m, self.dims.vocab as u32];
         self.sink_set_pipeline(&self.ps.scatter_logits_rows);
         self.sink_set_buffer(&self.bufs.logits, logits_off, 0);
         self.sink_set_buffer(&self.bufs.logits, 0, 1);
         self.sink_set_buffer(&self.bufs.route, token_list_off, 2);
         self.sink_set_bytes(&dims, 3);
         let grid = MTLSize {
-            width: VOCAB,
+            width: self.dims.vocab,
             height: m as usize,
             depth: 1,
         };
@@ -2825,19 +2842,19 @@ impl StepEnc<'_> {
             self.arena().hidden_off(),
             self.arena().tmp_off(),
             layout.final_norm,
-            HID as u32,
-            CANVAS,
+            self.dims.hid as u32,
+            self.dims.canvas,
         );
         let m = self.partial_lm_m;
-        if partial_lm_head_enabled() && m < CANVAS as u32 {
+        if partial_lm_head_enabled() && m < self.dims.canvas as u32 {
             self.encode_partial_lm_head(layout, m)?;
         } else {
             self.gemm_q8_logits(
                 self.arena().tmp_off(),
                 layout.embed,
-                CANVAS as u32,
-                VOCAB as u32,
-                HID as u32,
+                self.dims.canvas as u32,
+                self.dims.vocab as u32,
+                self.dims.hid as u32,
                 0,
             )?;
         }
@@ -2849,7 +2866,7 @@ impl StepEnc<'_> {
     }
 
     fn encode_step_sampler(&mut self, _layout: &ModelLayout) -> Result<(), Error> {
-        let cols = VOCAB as u32;
+        let cols = self.dims.vocab as u32;
         // Active denoise width (shrink-on-retry): the sampler stats
         // (mean-entropy, canvas-stable, accept-plateau) that drive early-stop
         // must cover exactly the active rows — stale rows [active..CANVAS) would
@@ -2949,7 +2966,7 @@ impl StepEnc<'_> {
         let st: CanvasState = read_struct(&self.bufs.state);
         let params: StepParams = read_struct(&self.bufs.params);
         let t = scheduled_temperature(st.step, &params).max(1e-6);
-        self.scale_half_logits(CANVAS * VOCAB, 1.0 / t);
+        self.scale_half_logits(self.dims.canvas * self.dims.vocab, 1.0 / t);
         Ok(())
     }
 }

--- a/src/metal/step_kernel/enc.rs
+++ b/src/metal/step_kernel/enc.rs
@@ -9,6 +9,7 @@ pub(super) struct StepEnc<'a> {
     pub(super) ctx: &'a MetalContext,
     pub(super) ps: &'a StepPipelines,
     pub(super) bufs: &'a StepBuffers,
+    pub(super) dims: &'a crate::metal::step_config::ModelDims,
     pub(super) block_profile: StepBlockProfile,
     pub(super) tensor_offsets: &'a HashMap<String, u64>,
     /// Active canvas rows for lm_head (P2.5); `CANVAS` when full lm_head.
@@ -875,7 +876,7 @@ impl StepEnc<'_> {
     ) -> Result<(), Error> {
         let fm = self.forward_m;
         let l = &layout.layers[layer];
-        let o_k = if l.is_full != 0 { 8192 } else { 4096 };
+        let o_k = self.dims.q_cols(l.is_full != 0) as u32;
         self.gemm_dense_linear(
             self.attn_format,
             self.arena().attno_off(),
@@ -1593,8 +1594,8 @@ impl StepEnc<'_> {
                 n_total,
             )?;
         } else {
-            let q_n = if l.is_full != 0 { 8192 } else { 4096 };
-            let k_n = if l.is_full != 0 { 1024 } else { 2048 };
+            let q_n = self.dims.q_cols(l.is_full != 0) as u32;
+            let k_n = self.dims.kv_cols(l.is_full != 0) as u32;
             self.gemm_dense_linear(
                 self.attn_format,
                 self.arena().tmp_off(),
@@ -1650,8 +1651,8 @@ impl StepEnc<'_> {
                 n_total,
             )?;
         } else {
-            let q_n = if l.is_full != 0 { 8192 } else { 4096 };
-            let k_n = if l.is_full != 0 { 1024 } else { 2048 };
+            let q_n = self.dims.q_cols(l.is_full != 0) as u32;
+            let k_n = self.dims.kv_cols(l.is_full != 0) as u32;
             self.gemm_dense_linear(
                 self.attn_format,
                 self.arena().tmp_off(),

--- a/src/metal/step_kernel/mod.rs
+++ b/src/metal/step_kernel/mod.rs
@@ -1050,10 +1050,10 @@ impl StepPipelines {
             gemm_q8_rowk_acc_f32,
             gemm_bf16_rowk_acc_f32,
             f32_to_half_scale,
-            qk_rope_kv: crate::shaders::qk_rope_kv::pipeline_for_kv(ctx, prod, fmt)?,
+            qk_rope_kv: crate::shaders::qk_rope_kv::pipeline_for_kv(ctx, prod, fmt, dims)?,
             qk_rope_kv_side: if crate::flags::prefill_kv_f32_enabled() {
                 Some(crate::shaders::qk_rope_kv::pipeline_for_kv_side(
-                    ctx, prod, fmt,
+                    ctx, prod, fmt, dims,
                 )?)
             } else {
                 None

--- a/src/metal/step_kernel/mod.rs
+++ b/src/metal/step_kernel/mod.rs
@@ -105,21 +105,21 @@ pub use crate::flags::{
 pub const MAX_ATTN_Q_COLS: usize = 8192;
 pub const MAX_ATTN_KV_COLS: usize = 2048;
 
-pub fn step_arena_params() -> ArenaLayoutParams {
+pub fn step_arena_params(dims: &crate::metal::step_config::ModelDims) -> ArenaLayoutParams {
     ArenaLayoutParams {
-        // Planes hold PREFILL_M rows so the batched prefill super-chunk (4x256
+        // Planes hold prefill_m rows so the batched prefill super-chunk (4x256
         // causal sub-chunks in ONE forward) fits; denoise dispatches only ever
-        // touch rows [0..CANVAS) of each plane. Arena ~25.6 -> ~102 MiB.
-        canvas: PREFILL_M,
-        hidden: HID,
-        dense_ff: DENSE_FF as usize,
+        // touch rows [0..canvas) of each plane. Arena ~25.6 -> ~102 MiB.
+        canvas: dims.prefill_m(),
+        hidden: dims.hid,
+        dense_ff: dims.dense_ff,
         max_attn_q_cols: MAX_ATTN_Q_COLS,
         max_attn_kv_cols: MAX_ATTN_KV_COLS,
     }
 }
 
-pub fn step_arena_layout() -> ArenaLayout {
-    build_arena_layout(&step_arena_params())
+pub fn step_arena_layout(dims: &crate::metal::step_config::ModelDims) -> ArenaLayout {
+    build_arena_layout(&step_arena_params(dims))
 }
 
 pub const MOE_ACT_PROBE_FLOATS: usize = MOE_ACT_PROBE_ACT_FLOATS + MOE_ACT_PROBE_META_FLOATS;
@@ -471,14 +471,15 @@ pub fn build_offsets_from_store(store: &DgqStore) -> HashMap<String, u64> {
 /// Per-expert weight byte offset from `.dgq` manifest (stack base + expert × matrix bytes).
 pub fn manifest_offset(
     offsets: &HashMap<String, u64>,
+    dims: &crate::metal::step_config::ModelDims,
     layer: usize,
     expert: usize,
     kind: &str,
     format: QuantFormat,
 ) -> u64 {
     use crate::dgq::layout::{nvfp4_matrix_bytes, q4_matrix_bytes};
-    let hidden = HID;
-    let moe_ff = MOE_FF as usize;
+    let hidden = dims.hid;
+    let moe_ff = dims.moe_ff;
     let (tensor, n, k) = match kind {
         "gate_up" => (
             format!("model.decoder.layers.{layer}.experts.gate_up_proj"),
@@ -656,23 +657,24 @@ pub(crate) fn qkv_stacked_segments(
 pub(crate) fn gate_up_stacked_segments(
     l: &LayerOffsets,
     arena: &ArenaLayout,
+    dense_ff: u32,
 ) -> ([crate::shaders::gemm_block_stacked::GemmStackedSeg; 2], u32) {
     use crate::shaders::gemm_block_stacked::GemmStackedSeg;
-    let n2 = DENSE_FF * 2;
+    let n2 = dense_ff * 2;
     (
         [
             GemmStackedSeg {
-                n_cols: DENSE_FF,
+                n_cols: dense_ff,
                 y_col0: 0,
-                y_row_cols: DENSE_FF,
+                y_row_cols: dense_ff,
                 _pad: 0,
                 w_off: l.mlp_gate,
                 y_byte_off: arena.ffg_off(),
             },
             GemmStackedSeg {
-                n_cols: DENSE_FF,
+                n_cols: dense_ff,
                 y_col0: 0,
-                y_row_cols: DENSE_FF,
+                y_row_cols: dense_ff,
                 _pad: 0,
                 w_off: l.mlp_up,
                 y_byte_off: arena.ffu_off(),
@@ -683,16 +685,17 @@ pub(crate) fn gate_up_stacked_segments(
 }
 
 /// Scratch byte sizes for step-kernel grouped GEMM (max over all MoE/dense shapes).
-fn gemm_scratch_bytes() -> (usize, usize) {
+fn gemm_scratch_bytes(dims: &crate::metal::step_config::ModelDims) -> (usize, usize) {
+    let (hid, dense_ff) = (dims.hid as u32, dims.dense_ff as u32);
     let shapes = [
-        (CANVAS, 4096u32, HID as u32),
-        (CANVAS, 2048, HID as u32),
-        (CANVAS, 2816, 4096),
-        (CANVAS, 8192, HID as u32),
-        (CANVAS, 1024, HID as u32),
-        (CANVAS, 2816, 8192),
-        (CANVAS, DENSE_FF, HID as u32),
-        (CANVAS, 2816, DENSE_FF),
+        (dims.canvas, dims.q_cols(false) as u32, hid),
+        (dims.canvas, dims.kv_cols(false) as u32, hid),
+        (dims.canvas, hid, dims.q_cols(false) as u32),
+        (dims.canvas, dims.q_cols(true) as u32, hid),
+        (dims.canvas, dims.kv_cols(true) as u32, hid),
+        (dims.canvas, hid, dims.q_cols(true) as u32),
+        (dims.canvas, dense_ff, hid),
+        (dims.canvas, hid, dense_ff),
     ];
     let mut max_mk = 0usize;
     let mut max_nk = 0usize;
@@ -705,19 +708,21 @@ fn gemm_scratch_bytes() -> (usize, usize) {
     // (PREFILL_M x HID) and the swiglu activations (MOE_SLOTS x MOE_FF);
     // gemm_b holds the gathered expert A (MOE_SLOTS x HID at offset 0) plus
     // the gate_up activations (MOE_SLOTS x 2*MOE_FF at moe_w_byte_off_gu).
-    let moe_slots = PREFILL_M * TOP_K;
-    max_mk = max_mk.max(PREFILL_M * HID).max(moe_slots * MOE_FF as usize);
-    max_nk = max_nk.max(moe_slots * (HID + 2 * MOE_FF as usize));
+    let moe_slots = dims.prefill_m() * dims.top_k;
+    max_mk = max_mk
+        .max(dims.prefill_m() * dims.hid)
+        .max(moe_slots * dims.moe_ff);
+    max_nk = max_nk.max(moe_slots * (dims.hid + 2 * dims.moe_ff));
     (max_mk * f32, max_nk * f32)
 }
 
 /// SC prob staging: one vocab chunk of fp16 probs (the chunked softembed path).
-fn sc_probs_buffer_bytes() -> usize {
-    CANVAS * crate::model::embed::LM_HEAD_CHUNK * 2
+fn sc_probs_buffer_bytes(dims: &crate::metal::step_config::ModelDims) -> usize {
+    dims.canvas * crate::model::embed::LM_HEAD_CHUNK * 2
 }
 
-fn logits_finite_sample_bytes() -> u64 {
-    (logits_finite_sample_count().min(CANVAS * VOCAB) * 2) as u64
+fn logits_finite_sample_bytes(dims: &crate::metal::step_config::ModelDims) -> u64 {
+    (logits_finite_sample_count().min(dims.canvas * dims.vocab) * 2) as u64
 }
 
 struct StepPipelines {
@@ -820,6 +825,7 @@ impl StepPipelines {
         ctx: &MetalContext,
         variant: crate::shaders::variant::KernelVariant,
         fmt: crate::shaders::kv_quant::KvFormat,
+        dims: &crate::metal::step_config::ModelDims,
     ) -> Result<Self, Error> {
         let mut gemm_tunable_raw = HashMap::new();
         let mut gemm_tunable_q8 = HashMap::new();
@@ -830,22 +836,25 @@ impl StepPipelines {
         let sparse_wide_bm = crate::flags::moe_prefill_block_m();
         let mut gemm_q8_rowk = HashMap::new();
         let mut gemm_q8_rowk_xfp16 = HashMap::new();
+        let hid = dims.hid as u32;
+        let dense_ff = dims.dense_ff as u32;
+        let vocab = dims.vocab as u32;
         for &(n, k) in &[
-            (4096u32, HID as u32),
-            (2048, HID as u32),
-            (2816, 4096),
-            (8192, HID as u32),
-            (1024, HID as u32),
-            (2816, 8192),
-            (DENSE_FF, HID as u32),
-            (2816, DENSE_FF),
-            (VOCAB as u32, HID as u32),
-            // Router logits GEMM (DGQ_ROUTER_GEMM): [256, HID] @ router_proj^T[128, HID].
-            (N_EXPERTS as u32, HID as u32),
+            (dims.q_cols(false) as u32, hid),
+            (dims.kv_cols(false) as u32, hid),
+            (hid, dims.q_cols(false) as u32),
+            (dims.q_cols(true) as u32, hid),
+            (dims.kv_cols(true) as u32, hid),
+            (hid, dims.q_cols(true) as u32),
+            (dense_ff, hid),
+            (hid, dense_ff),
+            (vocab, hid),
+            // Router logits GEMM (DGQ_ROUTER_GEMM): [canvas, hid] @ router_proj^T[n_experts, hid].
+            (dims.n_experts as u32, hid),
         ] {
             // Raw (bf16-weight) dense: lm_head logits (n=VOCAB) forces bf16
             // output (range); others follow K_ACT_F16 for their activation out.
-            let raw = if n == VOCAB as u32 {
+            let raw = if n == vocab {
                 crate::shaders::gemm_tunable::pipeline_for_logits(
                     ctx,
                     n,
@@ -883,20 +892,20 @@ impl StepPipelines {
             );
         }
         for &(n, k) in &[
-            (DENSE_FF, HID as u32),
-            (2816, DENSE_FF),
-            (VOCAB as u32, HID as u32),
+            (dense_ff, hid),
+            (hid, dense_ff),
+            (vocab, hid),
             // Attention q/k/v/o_proj shapes (mixed-precision q8 attention path).
-            (4096u32, HID as u32),
-            (2048, HID as u32),
-            (8192, HID as u32),
-            (1024, HID as u32),
-            (2816, 4096),
-            (2816, 8192),
+            (dims.q_cols(false) as u32, hid),
+            (dims.kv_cols(false) as u32, hid),
+            (dims.q_cols(true) as u32, hid),
+            (dims.kv_cols(true) as u32, hid),
+            (hid, dims.q_cols(false) as u32),
+            (hid, dims.q_cols(true) as u32),
         ] {
             // q8 dense: lm_head logits (VOCAB) forces bf16 output; others follow
             // the arena activation dtype.
-            let q8 = if (n, k) == (VOCAB as u32, HID as u32) {
+            let q8 = if (n, k) == (vocab, hid) {
                 crate::shaders::gemm_tunable::pipeline_for_logits(
                     ctx,
                     n,
@@ -914,8 +923,8 @@ impl StepPipelines {
             gemm_tunable_q8.insert((n, k), q8);
         }
         for &(n, k) in &[
-            (HID as u32, VOCAB as u32),
-            (HID as u32, crate::model::embed::LM_HEAD_CHUNK as u32),
+            (hid, vocab),
+            (hid, crate::model::embed::LM_HEAD_CHUNK as u32),
         ] {
             gemm_q8_rowk.insert((n, k), crate::shaders::gemm_rowk::pipeline_for(ctx, n, k)?);
             gemm_q8_rowk_xfp16.insert(
@@ -929,7 +938,7 @@ impl StepPipelines {
         let mut gemm_q8_rowk_acc_f32 = HashMap::new();
         {
             {
-                let &(n, k) = &(HID as u32, crate::model::embed::LM_HEAD_CHUNK as u32);
+                let &(n, k) = &(hid, crate::model::embed::LM_HEAD_CHUNK as u32);
                 gemm_q8_rowk_acc_f32.insert(
                     (n, k),
                     ctx.compile_gemm_subkernel(
@@ -947,7 +956,7 @@ impl StepPipelines {
         let mut gemm_bf16_rowk_acc_f32 = HashMap::new();
         {
             {
-                let &(n, k) = &(HID as u32, crate::model::embed::LM_HEAD_CHUNK as u32);
+                let &(n, k) = &(hid, crate::model::embed::LM_HEAD_CHUNK as u32);
                 gemm_bf16_rowk_acc_f32.insert(
                     (n, k),
                     ctx.compile_gemm_subkernel(
@@ -970,7 +979,8 @@ impl StepPipelines {
         // swiglu output. Wide variants = weight-stationary prefill height
         // (TUNE_BM=sparse_wide_bm; the batched-prefill block list is built at
         // this height).
-        for &(n, k) in &[(MOE_FF * 2, HID as u32), (HID as u32, MOE_FF)] {
+        let moe_ff = dims.moe_ff as u32;
+        for &(n, k) in &[(moe_ff * 2, hid), (hid, moe_ff)] {
             for fmt in [
                 crate::shaders::QuantFormat::Q4Affine,
                 crate::shaders::QuantFormat::Q6,
@@ -980,7 +990,7 @@ impl StepPipelines {
                     (n, k, false, fmt as u32),
                     crate::shaders::gemm_tunable::pipeline_for_sparse(ctx, n, k, false, fmt)?,
                 );
-                if moe_fuse_gather_enabled() && (n, k) == (MOE_FF * 2, HID as u32) {
+                if moe_fuse_gather_enabled() && (n, k) == (moe_ff * 2, hid) {
                     gemm_tunable_sparse.insert(
                         (n, k, true, fmt as u32),
                         crate::shaders::gemm_tunable::pipeline_for_sparse(ctx, n, k, true, fmt)?,
@@ -998,7 +1008,7 @@ impl StepPipelines {
                             sparse_wide_bm as usize,
                         )?,
                     );
-                    if moe_fuse_gather_enabled() && (n, k) == (MOE_FF * 2, HID as u32) {
+                    if moe_fuse_gather_enabled() && (n, k) == (moe_ff * 2, hid) {
                         gemm_tunable_sparse_wide.insert(
                             (n, k, true, fmt as u32),
                             crate::shaders::gemm_tunable::pipeline_for_sparse_bm(
@@ -1378,10 +1388,13 @@ fn moe_grouped_grid_info() -> MoeGroupedGridInfo {
     }
 }
 
-fn grouped_expert_blob_bytes_per_expert(format: crate::shaders::QuantFormat) -> u64 {
+fn grouped_expert_blob_bytes_per_expert(
+    format: crate::shaders::QuantFormat,
+    dims: &crate::metal::step_config::ModelDims,
+) -> u64 {
     use crate::dgq::layout::{nvfp4_matrix_bytes, q4_matrix_bytes};
-    let hidden = HID;
-    let moe_ff = MOE_FF as usize;
+    let hidden = dims.hid;
+    let moe_ff = dims.moe_ff;
     match format {
         crate::shaders::QuantFormat::NvFp4 => {
             (nvfp4_matrix_bytes(moe_ff * 2, hidden) + nvfp4_matrix_bytes(hidden, moe_ff)) as u64
@@ -1402,19 +1415,21 @@ fn moe_w_byte_off_gu() -> usize {
 pub fn layer_moe_block_jobs(
     l: &LayerOffsets,
     format: QuantFormat,
+    dims: &crate::metal::step_config::ModelDims,
 ) -> ([BlockGroupedJob; N_EXPERTS], [BlockGroupedJob; N_EXPERTS]) {
-    layer_moe_block_jobs_impl(l, format, None, 0)
+    layer_moe_block_jobs_impl(l, format, dims, None, 0)
 }
 
 fn layer_moe_block_jobs_impl(
     l: &LayerOffsets,
     format: QuantFormat,
+    dims: &crate::metal::step_config::ModelDims,
     manifest: Option<(usize, &HashMap<String, u64>)>,
     expert_base: u64,
 ) -> ([BlockGroupedJob; N_EXPERTS], [BlockGroupedJob; N_EXPERTS]) {
     use crate::dgq::layout::{nvfp4_matrix_bytes, q4_matrix_bytes, q6_matrix_bytes};
-    let hidden = HID;
-    let moe_ff = MOE_FF as usize;
+    let hidden = dims.hid;
+    let moe_ff = dims.moe_ff;
     let (gu_stride, dn_stride, gu_gpr, dn_gpr) = match format {
         QuantFormat::NvFp4 => (
             nvfp4_matrix_bytes(moe_ff * 2, hidden) as u64,
@@ -1451,7 +1466,7 @@ fn layer_moe_block_jobs_impl(
         if let Some((layer, offsets)) = manifest {
             debug_assert_eq!(
                 gate[e].w_byte_off,
-                manifest_offset(offsets, layer, e, "gate_up", format),
+                manifest_offset(offsets, dims, layer, e, "gate_up", format),
                 "gate_up L{layer} E{e}: computed stride offset != manifest"
             );
         }

--- a/src/metal/step_kernel/mod.rs
+++ b/src/metal/step_kernel/mod.rs
@@ -526,7 +526,21 @@ pub fn layer_kv_slots(is_full: bool, max_seq: usize) -> usize {
     }
 }
 
+/// Reference-checkpoint helper for tests and audits that run without a
+/// `config.json`; production paths call [`build_layout_with_dims`].
 pub fn build_layout(offsets: &HashMap<String, u64>, max_seq: usize) -> ModelLayout {
+    build_layout_with_dims(
+        offsets,
+        max_seq,
+        &crate::metal::step_config::ModelDims::reference(),
+    )
+}
+
+pub fn build_layout_with_dims(
+    offsets: &HashMap<String, u64>,
+    max_seq: usize,
+    dims: &crate::metal::step_config::ModelDims,
+) -> ModelLayout {
     // KV storage format is a per-session decision keyed off max_seq (plus the
     // DGQ_KV_Q8 override) — every sizing/pack/kernel site derives it the same
     // way so the layout stays coherent.
@@ -541,8 +555,8 @@ pub fn build_layout(offsets: &HashMap<String, u64>, max_seq: usize) -> ModelLayo
     let mut kv_off = 0u64;
     for (i, l) in layers.iter_mut().enumerate() {
         let p = format!("model.decoder.layers.{i}.");
-        let full = FULL_LAYERS.contains(&i);
-        let (hd, nkv) = if full { (512u32, 2u32) } else { (256, 8) };
+        let full = dims.is_full_layer(i);
+        let (hd, nkv) = (dims.head_dim(full) as u32, dims.kv_heads(full) as u32);
         let slots = layer_kv_slots(full, max_seq);
         *l = LayerOffsets {
             input_ln: g(&format!("{p}input_layernorm.weight")),

--- a/src/metal/step_kernel/runtime.rs
+++ b/src/metal/step_kernel/runtime.rs
@@ -21,6 +21,7 @@ pub struct StepRuntime {
     pub(super) gpu_blob: std::sync::Arc<DgqGpuBlob>,
     pub(super) weight_cache: GpuDecoderWeightCache,
     pub(super) text_config: TextConfig,
+    pub(super) dims: crate::metal::step_config::ModelDims,
     pub(super) block_profile: StepBlockProfile,
     pub(super) attn_format: crate::metal::step_quant::DenseWeightFormat,
     pub(super) dense_format: crate::metal::step_quant::DenseWeightFormat,
@@ -52,6 +53,11 @@ impl StepRuntime {
 
     pub fn layout(&self) -> &ModelLayout {
         &self.layout
+    }
+
+    /// Config-derived model geometry (see `ModelDims`).
+    pub fn dims(&self) -> &crate::metal::step_config::ModelDims {
+        &self.dims
     }
 
     /// Model sliding-window size (Gemma-4: 1024). A sliding layer's query at
@@ -598,6 +604,7 @@ impl StepRuntime {
             ctx: &self.ctx,
             ps,
             bufs: &self.bufs,
+            dims: &self.dims,
             block_profile: self.block_profile,
             tensor_offsets: &self.tensor_offsets,
             partial_lm_m: CANVAS as u32,

--- a/src/metal/step_kernel/runtime.rs
+++ b/src/metal/step_kernel/runtime.rs
@@ -93,9 +93,10 @@ impl StepRuntime {
         // the buffer) and corrupts attention into word-salad. Fail loudly instead —
         // callers must size max_seq >= prompt + generated + CANVAS.
         assert!(
-            kv_len as usize + CANVAS <= self.max_seq,
-            "KV cache overflow: kv_len={kv_len} + CANVAS={CANVAS} > max_seq={}; \
-             size max_seq >= prompt_len + max_new_tokens + CANVAS",
+            kv_len as usize + self.dims.canvas <= self.max_seq,
+            "KV cache overflow: kv_len={kv_len} + canvas={} > max_seq={}; \
+             size max_seq >= prompt_len + max_new_tokens + canvas",
+            self.dims.canvas,
             self.max_seq,
         );
         let mut params = self.read_params();
@@ -328,13 +329,13 @@ impl StepRuntime {
         let probe_planes = |this: &Self, m_rows: usize, peaks: &mut RangePeaks| {
             let a = &this.bufs.arena_map;
             for (label, off, per_row) in [
-                ("hidden", a.hidden_off(), HID),
+                ("hidden", a.hidden_off(), this.dims.hid),
                 ("attnq(Q)", a.attnq_off(), 4096),
                 ("attn_out", a.attno_off(), 4096),
-                ("tmp(o_proj)", a.tmp_off(), HID),
-                ("ffg(gate_up)", a.ffg_off(), DENSE_FF as usize),
-                ("dense", a.dense_off(), HID),
-                ("moein", a.moein_off(), HID),
+                ("tmp(o_proj)", a.tmp_off(), this.dims.hid),
+                ("ffg(gate_up)", a.ffg_off(), this.dims.dense_ff),
+                ("dense", a.dense_off(), this.dims.hid),
+                ("moein", a.moein_off(), this.dims.hid),
             ] {
                 // half_buffer_stats returns (finite, max_abs) — bool true = healthy.
                 let (finite, mx) = if this.arena_f16_mode {
@@ -379,12 +380,12 @@ impl StepRuntime {
             // forward (needs kv headroom for the whole super-chunk). The tail
             // (< 2 full chunks) falls back to plain 256-chunks.
             let n_subs = if batch {
-                (remaining / CANVAS).min(PREFILL_SUBS)
+                (remaining / self.dims.canvas).min(PREFILL_SUBS)
             } else {
                 1
             };
-            if n_subs >= 2 && pos + n_subs * CANVAS + CANVAS <= self.max_seq {
-                let m = n_subs * CANVAS;
+            if n_subs >= 2 && pos + n_subs * self.dims.canvas + self.dims.canvas <= self.max_seq {
+                let m = n_subs * self.dims.canvas;
                 self.set_canvas_ids(&delta_token_ids[pos - offset..pos - offset + m])?;
                 self.set_kv_len(pos as u32);
                 self.write_params_sub(pos as u32, n_subs);
@@ -395,7 +396,7 @@ impl StepRuntime {
                 pos += m;
                 continue;
             }
-            let chunk_len = remaining.min(CANVAS);
+            let chunk_len = remaining.min(self.dims.canvas);
             let mut ids = [0u32; CANVAS];
             ids[..chunk_len]
                 .copy_from_slice(&delta_token_ids[pos - offset..pos - offset + chunk_len]);
@@ -403,7 +404,7 @@ impl StepRuntime {
             self.set_kv_len(pos as u32);
             self.dispatch_and_wait(|enc| enc.encode_prefill_chunk(&layout, layers))?;
             if let Some(peaks) = range_peaks.as_mut() {
-                probe_planes(self, CANVAS, peaks);
+                probe_planes(self, self.dims.canvas, peaks);
             }
             pos += chunk_len;
         }
@@ -442,7 +443,7 @@ impl StepRuntime {
     pub fn read_sample_rowstats(&self, rows: usize) -> Vec<[f32; 2]> {
         let byte_off = self.bufs.arena_map.rs_samp_off() as usize;
         let ptr = unsafe { self.bufs.arena.contents().as_ptr().add(byte_off) as *const f32 };
-        (0..rows.min(CANVAS))
+        (0..rows.min(self.dims.canvas))
             .map(|r| unsafe { [*ptr.add(r * 2), *ptr.add(r * 2 + 1)] })
             .collect()
     }
@@ -456,20 +457,22 @@ impl StepRuntime {
     /// the feature is off.
     pub fn read_hidden_rows(&self, rows: usize) -> Vec<f32> {
         let byte_off = self.bufs.arena_map.hidden_off() as usize;
-        let n = rows.min(CANVAS);
+        let n = rows.min(self.dims.canvas);
         crate::metal::step_kernel::diag_bench::read_arena_buffer_f32(
             &self.bufs.arena,
             byte_off,
-            n * HID,
+            n * self.dims.hid,
         )
     }
 
     pub fn set_canvas_ids(&mut self, ids: &[u32]) -> Result<(), Error> {
         // CANVAS for denoise / plain prefill chunks; up to PREFILL_M for a
         // batched prefill super-chunk.
-        if ids.len() != CANVAS && (ids.len() > PREFILL_M || !ids.len().is_multiple_of(CANVAS)) {
+        if ids.len() != self.dims.canvas
+            && (ids.len() > self.dims.prefill_m() || !ids.len().is_multiple_of(self.dims.canvas))
+        {
             return Err(Error::Format(
-                "canvas ids length must be CANVAS..=PREFILL_M",
+                "canvas ids length must be self.dims.canvas..=self.dims.prefill_m()",
             ));
         }
         let mut state = self.read_canvas_state();
@@ -486,7 +489,7 @@ impl StepRuntime {
         let mut p = read_struct::<StepParams>(&self.bufs.params);
         let ptr = self.bufs.params_sub.contents().as_ptr() as *mut StepParams;
         for c in 0..n_subs {
-            p.kv_len = base_kv_len + (c * CANVAS) as u32;
+            p.kv_len = base_kv_len + (c * self.dims.canvas) as u32;
             unsafe { std::ptr::write(ptr.add(c), p) };
         }
     }
@@ -500,7 +503,7 @@ impl StepRuntime {
     /// Clamped to [1, CANVAS]. A `DGQ_FORCE_CANVAS` override still wins at the
     /// dispatch site. The block loop reads it back via `active_canvas()`.
     pub fn set_active_canvas(&mut self, w: usize) {
-        self.active_canvas = w.clamp(1, CANVAS);
+        self.active_canvas = w.clamp(1, self.dims.canvas);
     }
 
     /// Effective active canvas width (the `DGQ_FORCE_CANVAS` test override, else
@@ -508,7 +511,7 @@ impl StepRuntime {
     /// stats/trim to this many rows.
     pub fn active_canvas(&self) -> usize {
         crate::flags::force_canvas()
-            .map(|w| (w as usize).clamp(1, CANVAS))
+            .map(|w| (w as usize).clamp(1, self.dims.canvas))
             .unwrap_or(self.active_canvas)
     }
 
@@ -537,7 +540,8 @@ impl StepRuntime {
     pub fn fill_expert_forward_telemetry(&self, forward: &mut crate::metal::ForwardTelemetry) {
         let ptr = self.bufs.expert_layer_unique.contents().as_ptr() as *const u32;
         let counts = unsafe { std::slice::from_raw_parts(ptr, self.layers) };
-        let weight_bytes = grouped_expert_blob_bytes_per_expert(self.block_profile.format);
+        let weight_bytes =
+            grouped_expert_blob_bytes_per_expert(self.block_profile.format, &self.dims);
         forward.record_expert_layers_grouped(counts, weight_bytes);
     }
 
@@ -545,11 +549,14 @@ impl StepRuntime {
     pub const CANVAS_STATE_BYTES: usize = std::mem::size_of::<CanvasState>();
 
     /// P2.1 budget: host bytes touched per denoise step on the generate hot path.
-    pub fn denoise_step_host_readback_bytes(check_logits: bool) -> u64 {
+    pub fn denoise_step_host_readback_bytes(
+        check_logits: bool,
+        dims: &crate::metal::step_config::ModelDims,
+    ) -> u64 {
         // Forward reads state once on CPU to seed preamble; generate polls once after sync.
         let mut bytes = (Self::CANVAS_STATE_BYTES as u64) * 2;
         if check_logits && logits_finite_check_enabled() {
-            bytes += logits_finite_sample_bytes();
+            bytes += logits_finite_sample_bytes(dims);
         }
         bytes
     }
@@ -559,8 +566,13 @@ impl StepRuntime {
         if !logits_finite_check_enabled() {
             return Ok(());
         }
-        let sample = logits_finite_sample_count().min(CANVAS * VOCAB);
-        let (finite, max_abs) = half_buffer_stats(&self.bufs.logits, 0, CANVAS * VOCAB, sample);
+        let sample = logits_finite_sample_count().min(self.dims.canvas * self.dims.vocab);
+        let (finite, max_abs) = half_buffer_stats(
+            &self.bufs.logits,
+            0,
+            self.dims.canvas * self.dims.vocab,
+            sample,
+        );
         if !finite {
             eprintln!("non-finite logits (max_abs={max_abs:.4}, sample={sample})");
             return Err(Error::Runtime("non-finite logits"));
@@ -607,14 +619,14 @@ impl StepRuntime {
             dims: &self.dims,
             block_profile: self.block_profile,
             tensor_offsets: &self.tensor_offsets,
-            partial_lm_m: CANVAS as u32,
+            partial_lm_m: self.dims.canvas as u32,
             attn_format: self.attn_format,
             dense_format: self.dense_format,
             sc_format: self.sc_format,
             embed_bf16: self.embed_bf16,
             prefill_causal: false,
-            forward_m: CANVAS,
-            active_canvas: CANVAS,
+            forward_m: self.dims.canvas,
+            active_canvas: self.dims.canvas,
             sub_c: 0,
             use_params_sub: false,
             sliding_window: self.text_config.sliding_window as u32,
@@ -644,17 +656,17 @@ impl StepRuntime {
         let moe_in = read_arena_buffer_f32(
             &self.bufs.arena,
             self.bufs.arena_map.moein_off() as usize,
-            CANVAS * HID,
+            self.dims.canvas * self.dims.hid,
         );
-        let mut moe_out = vec![0.0f32; CANVAS * HID];
-        let mut scratch = MoeScratch::new(CANVAS, &self.text_config);
+        let mut moe_out = vec![0.0f32; self.dims.canvas * self.dims.hid];
+        let mut scratch = MoeScratch::new(self.dims.canvas, &self.text_config);
         experts_forward_dgq_cpu(
             &mut moe_out,
             &moe_in,
             &self.weight_cache,
             layer,
             &self.text_config,
-            CANVAS,
+            self.dims.canvas,
             &routes,
             &mut scratch,
         )?;
@@ -778,19 +790,19 @@ impl StepRuntime {
             self,
             "preamble:soft",
             self.bufs.arena_map.soft_off(),
-            CANVAS * HID,
+            self.dims.canvas * self.dims.hid,
         );
         probe(
             self,
             "preamble:dense(sc_mlp)",
             self.bufs.arena_map.dense_off(),
-            CANVAS * HID,
+            self.dims.canvas * self.dims.hid,
         );
         probe(
             self,
             "preamble:hidden(embed+sc)",
             self.bufs.arena_map.hidden_off(),
-            CANVAS * HID,
+            self.dims.canvas * self.dims.hid,
         );
 
         for layer in 0..layers {
@@ -805,46 +817,66 @@ impl StepRuntime {
                 a.moein_off(),
             );
             self.time_enc_stage(|e| e.encode_layer_qkv_gemm(layer, &layout))?;
-            probe(self, "layer:qkv(Q)", attnq, CANVAS * 4096);
+            probe(self, "layer:qkv(Q)", attnq, self.dims.canvas * 4096);
             self.time_enc_stage(|e| e.encode_layer_qk_rope_kv_dispatch(layer, &layout))?;
             self.time_enc_stage(|e| e.encode_layer_attention_dispatch(layer, &layout))?;
-            probe(self, "layer:attn_out", attno, CANVAS * 4096);
+            probe(self, "layer:attn_out", attno, self.dims.canvas * 4096);
             self.time_enc_stage(|e| e.encode_layer_o_proj_gemm(layer, &layout))?;
-            probe(self, "layer:o_proj", tmp, CANVAS * HID);
+            probe(self, "layer:o_proj", tmp, self.dims.canvas * self.dims.hid);
             self.time_enc_stage(|e| e.encode_layer_o_proj_tail(layer, &layout))?;
-            probe(self, "layer:resid_pre_moe(hidden)", hidden, CANVAS * HID);
+            probe(
+                self,
+                "layer:resid_pre_moe(hidden)",
+                hidden,
+                self.dims.canvas * self.dims.hid,
+            );
             let l = &layout.layers[layer];
             self.time_enc_stage(|e| {
                 e.rmsnorm(
                     e.arena().stream_off(),
                     e.arena().tmp_off(),
                     l.pre_ff_ln,
-                    HID as u32,
-                    CANVAS,
+                    e.dims.hid as u32,
+                    e.dims.canvas,
                 );
                 Ok(())
             })?;
             self.time_enc_stage(|e| e.encode_layer_dense_gate_up(layer, &layout))?;
-            probe(self, "layer:gate_up", ffg, CANVAS * DENSE_FF as usize);
+            probe(
+                self,
+                "layer:gate_up",
+                ffg,
+                self.dims.canvas * self.dims.dense_ff,
+            );
             self.time_enc_stage(|e| {
                 e.glu(
                     e.arena().ffg_off(),
                     e.arena().ffu_off(),
                     e.arena().ffg_off(),
-                    CANVAS * DENSE_FF as usize,
+                    e.dims.canvas * e.dims.dense_ff,
                 );
                 Ok(())
             })?;
-            probe(self, "layer:swiglu", ffg, CANVAS * DENSE_FF as usize);
+            probe(
+                self,
+                "layer:swiglu",
+                ffg,
+                self.dims.canvas * self.dims.dense_ff,
+            );
             self.time_enc_stage(|e| e.encode_layer_dense_down(layer, &layout))?;
-            probe(self, "layer:dense_down", dense, CANVAS * HID);
+            probe(
+                self,
+                "layer:dense_down",
+                dense,
+                self.dims.canvas * self.dims.hid,
+            );
             self.time_enc_stage(|e| {
                 e.rmsnorm(
                     e.arena().dense_off(),
                     e.arena().dense_off(),
                     l.post_ff_ln_1,
-                    HID as u32,
-                    CANVAS,
+                    e.dims.hid as u32,
+                    e.dims.canvas,
                 );
                 Ok(())
             })?;
@@ -855,12 +887,26 @@ impl StepRuntime {
             self.time_enc_stage(|e| e.encode_moe_batched_down(layer, &layout))?;
             self.time_enc_stage(|e| e.encode_moe_batched_scatter())?;
             self.time_enc_stage(|e| e.encode_layer_moe_post_norm(layer, &layout))?;
-            probe(self, "layer:moe_norm(moein)", moein, CANVAS * HID);
+            probe(
+                self,
+                "layer:moe_norm(moein)",
+                moein,
+                self.dims.canvas * self.dims.hid,
+            );
             self.time_enc_stage(|e| e.encode_layer_moe_post_combine(layer, &layout))?;
-            probe(self, "layer:resid_post_moe(hidden)", hidden, CANVAS * HID);
+            probe(
+                self,
+                "layer:resid_post_moe(hidden)",
+                hidden,
+                self.dims.canvas * self.dims.hid,
+            );
             // Per-layer residual peak (the f16-overflow suspect).
-            let (_, hmx) =
-                half_buffer_stats(&self.bufs.arena, hidden as usize, CANVAS * HID, SAMPLE);
+            let (_, hmx) = half_buffer_stats(
+                &self.bufs.arena,
+                hidden as usize,
+                self.dims.canvas * self.dims.hid,
+                SAMPLE,
+            );
             eprintln!("  layer {layer:>2}: residual(hidden) max|x| = {hmx:.1}");
         }
 
@@ -914,8 +960,8 @@ impl StepRuntime {
                     e.arena().stream_off(),
                     e.arena().tmp_off(),
                     l.pre_ff_ln,
-                    HID as u32,
-                    CANVAS,
+                    e.dims.hid as u32,
+                    e.dims.canvas,
                 );
                 Ok(())
             })?;
@@ -926,7 +972,7 @@ impl StepRuntime {
                     e.arena().ffg_off(),
                     e.arena().ffu_off(),
                     e.arena().ffg_off(),
-                    CANVAS * DENSE_FF as usize,
+                    e.dims.canvas * e.dims.dense_ff,
                 );
                 Ok(())
             })?;
@@ -937,8 +983,8 @@ impl StepRuntime {
                     e.arena().dense_off(),
                     e.arena().dense_off(),
                     l.post_ff_ln_1,
-                    HID as u32,
-                    CANVAS,
+                    e.dims.hid as u32,
+                    e.dims.canvas,
                 );
                 Ok(())
             })?;
@@ -991,7 +1037,7 @@ impl StepRuntime {
         let layout = self.layout;
         let layers = self.layers;
         let n_subs = n_subs.clamp(1, PREFILL_SUBS);
-        let m = n_subs * CANVAS;
+        let m = n_subs * self.dims.canvas;
         let ids = vec![0u32; m];
         self.set_canvas_ids(&ids)?;
         self.set_kv_len(kv_len);
@@ -1072,7 +1118,7 @@ impl StepRuntime {
         let layers = self.layers;
         let st_before: CanvasState = read_struct(&self.bufs.state);
         if crate::metal::embed::sc_log_enabled() && st_before.step >= 1 {
-            let elems = CANVAS * VOCAB;
+            let elems = self.dims.canvas * self.dims.vocab;
             let sample = elems.min(8192);
             let (nf, mx) = half_buffer_stats(&self.bufs.logits, 0, elems, sample);
             eprintln!(
@@ -1086,11 +1132,11 @@ impl StepRuntime {
         // ForwardOnly (prefill/dump) always uses the full CANVAS sub width.
         let active_canvas = if finish == StepFinishMode::Full {
             crate::flags::force_canvas()
-                .map(|w| (w as usize).clamp(1, CANVAS))
+                .map(|w| (w as usize).clamp(1, self.dims.canvas))
                 .unwrap_or(self.active_canvas)
-                .clamp(1, CANVAS)
+                .clamp(1, self.dims.canvas)
         } else {
-            CANVAS
+            self.dims.canvas
         };
         self.dispatch_and_wait(|enc| {
             enc.partial_lm_m = partial_lm_m;

--- a/src/metal/step_kernel/tests.rs
+++ b/src/metal/step_kernel/tests.rs
@@ -449,9 +449,9 @@ fn fused_gate_up_gemm_matches_split_in_full_arena() {
     let store = crate::dgq::store::DgqStore::open(dir).expect("dgq");
     let offsets = build_offsets_from_store(&store);
     let layout = build_layout(&offsets, 512);
-    let arena_map = step_arena_layout();
+    let arena_map = step_arena_layout(&crate::metal::step_config::ModelDims::reference());
     let l = &layout.layers[0];
-    let (segs, n_total) = gate_up_stacked_segments(l, &arena_map);
+    let (segs, n_total) = gate_up_stacked_segments(l, &arena_map, DENSE_FF);
 
     let ctx = MetalContext::new().expect("metal");
     let gpu_blob = DgqGpuBlob::from_store(&store, &ctx.device).expect("blob");

--- a/src/shaders/attn/qk_rope_kv/mod.rs
+++ b/src/shaders/attn/qk_rope_kv/mod.rs
@@ -275,12 +275,37 @@ pub fn pipeline_for_kv(
     ctx: &crate::metal::device::MetalContext,
     variant: KernelVariant,
     fmt: crate::shaders::kv_quant::KvFormat,
+    dims: &crate::metal::ModelDims,
 ) -> Result<crate::metal::device::ComputePipeline, Error> {
-    let uints = [crate::shaders::variant::FcUInt {
-        index: 4,
-        value: fmt.code(),
-    }];
-    ctx.compile_subkernel_ex(SHADER, ENTRY, variant, fmt.label(), &[], &uints)
+    let uints = [
+        crate::shaders::variant::FcUInt {
+            index: 4,
+            value: fmt.code(),
+        },
+        crate::shaders::variant::FcUInt {
+            index: 11,
+            value: dims.rot_sliding as u32,
+        },
+        crate::shaders::variant::FcUInt {
+            index: 12,
+            value: dims.rot_full as u32,
+        },
+    ];
+    let floats = rope_theta_fcs(dims);
+    ctx.compile_subkernel_ex_floats(SHADER, ENTRY, variant, fmt.label(), &[], &uints, &floats)
+}
+
+fn rope_theta_fcs(dims: &crate::metal::ModelDims) -> [crate::shaders::variant::FcFloat; 2] {
+    [
+        crate::shaders::variant::FcFloat {
+            index: 5,
+            value: dims.rope_theta_sliding as f32,
+        },
+        crate::shaders::variant::FcFloat {
+            index: 6,
+            value: dims.rope_theta_full as f32,
+        },
+    ]
 }
 
 /// Sliding layers also write post-RoPE K / normed V into the f32 side ring (buffer 9).
@@ -289,17 +314,36 @@ pub fn pipeline_for_kv_side(
     ctx: &crate::metal::device::MetalContext,
     variant: KernelVariant,
     fmt: crate::shaders::kv_quant::KvFormat,
+    dims: &crate::metal::ModelDims,
 ) -> Result<crate::metal::device::ComputePipeline, Error> {
-    let uints = [crate::shaders::variant::FcUInt {
-        index: 4,
-        value: fmt.code(),
-    }];
+    let uints = [
+        crate::shaders::variant::FcUInt {
+            index: 4,
+            value: fmt.code(),
+        },
+        crate::shaders::variant::FcUInt {
+            index: 11,
+            value: dims.rot_sliding as u32,
+        },
+        crate::shaders::variant::FcUInt {
+            index: 12,
+            value: dims.rot_full as u32,
+        },
+    ];
     let bools = [crate::shaders::variant::FcBool {
         index: 30,
         value: true,
     }];
     let label = format!("{}_side", fmt.label());
-    ctx.compile_subkernel_ex(SHADER, ENTRY, variant, &label, &bools, &uints)
+    ctx.compile_subkernel_ex_floats(
+        SHADER,
+        ENTRY,
+        variant,
+        &label,
+        &bools,
+        &uints,
+        &rope_theta_fcs(dims),
+    )
 }
 
 #[cfg(target_os = "macos")]

--- a/src/shaders/attn/qk_rope_kv/qk_rope_kv.metal
+++ b/src/shaders/attn/qk_rope_kv/qk_rope_kv.metal
@@ -7,6 +7,13 @@ using namespace metal;
 #include "attention_device.metal"
 #include "sampler_device.metal"
 
+// RoPE geometry from config.json; unset (tier-1 harnesses) keeps the
+// reference checkpoint values via the fallbacks below.
+constant float ROPE_THETA_SLIDING_FC [[function_constant(5)]];
+constant float ROPE_THETA_FULL_FC [[function_constant(6)]];
+constant uint ROPE_ROT_SLIDING_FC [[function_constant(11)]];
+constant uint ROPE_ROT_FULL_FC [[function_constant(12)]];
+
 // Session-wide KV storage format: q8 (group-32) for long-context sessions,
 // f16 otherwise. Unset (oracle/test compiles) = f16.
 constant uint KV_FMT_FC [[function_constant(4)]];
@@ -58,8 +65,12 @@ kernel void qk_rope_kv(
     // a LIVE sliding-ring slot and clobbers the oldest window content).
     const bool kv_write = pos < P.kv_write_end;
     const bool full = L->is_full != 0u;
-    const uint rot = full ? (hd / 4u) : hd;
-    const float theta = full ? 1.0e6f : 1.0e4f;
+    const uint rot = full
+        ? (is_function_constant_defined(ROPE_ROT_FULL_FC) ? ROPE_ROT_FULL_FC : (hd / 4u))
+        : (is_function_constant_defined(ROPE_ROT_SLIDING_FC) ? ROPE_ROT_SLIDING_FC : hd);
+    const float theta = full
+        ? (is_function_constant_defined(ROPE_THETA_FULL_FC) ? ROPE_THETA_FULL_FC : 1.0e6f)
+        : (is_function_constant_defined(ROPE_THETA_SLIDING_FC) ? ROPE_THETA_SLIDING_FC : 1.0e4f);
 
     const bool isQ = h < dims.n_q_heads;
     const bool isK = !isQ && h < (dims.n_q_heads + nkv);

--- a/src/shaders/common/variant.rs
+++ b/src/shaders/common/variant.rs
@@ -166,3 +166,10 @@ pub struct FcUInt {
     pub index: u32,
     pub value: u32,
 }
+
+/// Optional float function constant beyond the shared triple (index ≥ 4).
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct FcFloat {
+    pub index: u32,
+    pub value: f32,
+}

--- a/src/shaders/moe/batched_pin.rs
+++ b/src/shaders/moe/batched_pin.rs
@@ -1,6 +1,6 @@
 //! Tier-1 pin: batched MoE pipeline stages with real routed jobs from denoise capture.
 
-use crate::metal::{HID, LayerOffsets, MOE_FF, N_EXPERTS, RouteScratch, layer_moe_block_jobs};
+use crate::metal::{LayerOffsets, MOE_FF, N_EXPERTS, RouteScratch, layer_moe_block_jobs};
 use crate::shaders::QuantFormat;
 use crate::shaders::cpu::gemm_linear_grouped::gemm_linear_grouped_cpu;
 use crate::shaders::cpu::moe_scatter_weighted::moe_scatter_weighted;
@@ -300,13 +300,14 @@ pub fn verify_batched_stages_cpu(
     MoeBatchedPinStageCos,
     GateUpDiffAnalysis,
 ) {
-    let hidden = HID;
-    let moe_ff = MOE_FF as usize;
+    let dims = crate::metal::ModelDims::reference();
+    let hidden = dims.hid;
+    let moe_ff = dims.moe_ff;
     let slots = route.num_slots as usize;
     let token_list = &route.token_list[..slots];
 
     let gather_cpu = cpu_gather_slots(moe_in, token_list, hidden);
-    let (gate_jobs, down_jobs) = layer_moe_block_jobs(layer_off, format);
+    let (gate_jobs, down_jobs) = layer_moe_block_jobs(layer_off, format, &dims);
     let row_start = &route.row_start[..=N_EXPERTS];
 
     let gate_up_cpu = gemm_linear_grouped_cpu(


### PR DESCRIPTION
## What

Stages 0–4 of the model de-hardcoding: "same architecture, different size" becomes a config change on the Rust side. Four commits, each individually golden-gated 8/8 byte-identical:

1. **`ModelDims`** — the full model geometry derived from `config.json` (dims, per-layer-kind head geometry, `full_layers` as data, eps, rope), stored on `StepRuntime`/`StepEnc`, with a test proving the derivation reproduces every hardcoded value.
2. **Layout + QKV geometry** — `build_layout_with_dims` computes per-layer `full`/`head_dim`/`kv_heads` from dims; the `FULL_LAYERS` table and `(512,2)/(256,8)` literal leave the layout path; enc.rs's `q_n/k_n/o_k` literals derive from head geometry.
3. **Full dims threading** — every `HID/VOCAB/CANVAS/PREFILL_M/DENSE_FF/MOE_FF/N_EXPERTS/TOP_K` read on the dispatch path (269 sites in enc.rs + runtime.rs), the sizing functions, and the hand-enumerated `(N,K)` pipeline list all derive from dims; build side and lookup side agree by construction. The process-global pipeline cache key gains a dims fingerprint.
4. **RoPE from config** — theta and rotated dims arrive as function constants (FC5/6/11/12 on `qk_rope_kv`, registered in its SPEC) set from `rope_parameters` including `partial_rotary_factor`; unset falls back to reference values so tier-1 harnesses are untouched. gpukit `FcValues` gains float constants.

## What deliberately stays compile-time

The `#[repr(C)]` GPU-shared capacity arrays (`CanvasState`, `RouteScratch`, `ModelLayout.layers`) and the shader `MOE_MAX_*`/sampler capacity constants — these are the caps the upcoming envelope validation will check `≤` against. `validate_step_model` still enforces exact equality with the reference geometry, so behavior is unchanged; relaxing it to envelope checks is the next stage, along with the `attention_mma_full` HD axis.

Diag/dump/test helpers pinned to the reference checkpoint use an explicit `ModelDims::reference()` rather than silently baked constants.

## Gates

- Full suite: diffgemma 789/0 (33 ignored), gpukit 4/4
- `golden`: 8/8 byte-identical after every commit
- build / clippy / fmt: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
